### PR TITLE
Fixes for compilation under C++11

### DIFF
--- a/src/Foundation/PDB_BitUtil.h
+++ b/src/Foundation/PDB_BitUtil.h
@@ -7,43 +7,46 @@ extern unsigned char _BitScanForward(unsigned long* _Index, unsigned long _Mask)
 #pragma intrinsic(_BitScanForward)
 
 
-namespace PDB::BitUtil
+namespace PDB
 {
-	template <typename T>
-	PDB_NO_DISCARD inline constexpr bool IsPowerOfTwo(T value) PDB_NO_EXCEPT
+	namespace BitUtil
 	{
-		static_assert(std::is_unsigned<T>::value == true, "T must be an unsigned type.");
+		template <typename T>
+		PDB_NO_DISCARD inline constexpr bool IsPowerOfTwo(T value) PDB_NO_EXCEPT
+		{
+			static_assert(std::is_unsigned<T>::value == true, "T must be an unsigned type.");
 
-		PDB_ASSERT(value != 0u, "Invalid value.");
+			PDB_ASSERT(value != 0u, "Invalid value.");
 
-		return (value & (value - 1u)) == 0u;
-	}
+			return (value & (value - 1u)) == 0u;
+		}
 
 
-	template <typename T>
-	PDB_NO_DISCARD inline constexpr T RoundUpToMultiple(T numToRound, T multipleOf) PDB_NO_EXCEPT
-	{
-		static_assert(std::is_unsigned<T>::value == true, "T must be an unsigned type.");
+		template <typename T>
+		PDB_NO_DISCARD inline constexpr T RoundUpToMultiple(T numToRound, T multipleOf) PDB_NO_EXCEPT
+		{
+			static_assert(std::is_unsigned<T>::value == true, "T must be an unsigned type.");
 
-		PDB_ASSERT(IsPowerOfTwo(multipleOf), "Multiple must be a power-of-two.");
+			PDB_ASSERT(IsPowerOfTwo(multipleOf), "Multiple must be a power-of-two.");
 
-		return (numToRound + (multipleOf - 1u)) & ~(multipleOf - 1u);
-	}
+			return (numToRound + (multipleOf - 1u)) & ~(multipleOf - 1u);
+		}
 
-	
-	// Finds the position of the first set bit in the given value starting from the LSB, e.g. FindFirstSetBit(0b00000010) == 1.
-	// This operation is also known as CTZ (Count Trailing Zeros).
-	template <typename T>
-	PDB_NO_DISCARD inline uint32_t FindFirstSetBit(T value) PDB_NO_EXCEPT;
 
-	template <>
-	PDB_NO_DISCARD inline uint32_t FindFirstSetBit(uint32_t value) PDB_NO_EXCEPT
-	{
-		PDB_ASSERT(value != 0u, "Invalid value.");
+		// Finds the position of the first set bit in the given value starting from the LSB, e.g. FindFirstSetBit(0b00000010) == 1.
+		// This operation is also known as CTZ (Count Trailing Zeros).
+		template <typename T>
+		PDB_NO_DISCARD inline uint32_t FindFirstSetBit(T value) PDB_NO_EXCEPT;
 
-		unsigned long result = 0u;
-		_BitScanForward(&result, value);
+		template <>
+		PDB_NO_DISCARD inline uint32_t FindFirstSetBit(uint32_t value) PDB_NO_EXCEPT
+		{
+			PDB_ASSERT(value != 0u, "Invalid value.");
 
-		return result;
+			unsigned long result = 0u;
+			_BitScanForward(&result, value);
+
+			return result;
+		}
 	}
 }

--- a/src/Foundation/PDB_Macros.h
+++ b/src/Foundation/PDB_Macros.h
@@ -14,7 +14,16 @@
 #define PDB_NO_ALIAS								__declspec(restrict)
 
 // Indicates to the compiler that the return value of a function or class should not be ignored.
-#define PDB_NO_DISCARD								[[nodiscard]]
+#ifdef __has_cpp_attribute
+#	if __has_cpp_attribute(nodiscard)
+#		define PDB_NO_DISCARD						[[nodiscard]]
+#	endif
+#endif
+
+// If PDB_NO_DISCARD is not defined because this compiler does not support it, define it to be empty
+#ifndef PDB_NO_DISCARD
+#	define PDB_NO_DISCARD
+#endif
 
 // Indicates to the compiler that a function does not throw an exception.
 #define PDB_NO_EXCEPT								noexcept

--- a/src/Foundation/PDB_PointerUtil.h
+++ b/src/Foundation/PDB_PointerUtil.h
@@ -4,25 +4,28 @@
 #pragma once
 
 
-namespace PDB::Pointer
+namespace PDB
 {
-	// Offsets any pointer by a given number of bytes.
-	template <typename T, typename U, typename V>
-	PDB_NO_DISCARD inline T Offset(U* anyPointer, V howManyBytes) PDB_NO_EXCEPT
+	namespace Pointer
 	{
-		static_assert(std::is_pointer<T>::value == true, "Type T must be a pointer type.");
-		static_assert(std::is_const<typename std::remove_pointer<T>::type>::value == std::is_const<U>::value, "Wrong constness.");
-
-		union
+		// Offsets any pointer by a given number of bytes.
+		template <typename T, typename U, typename V>
+		PDB_NO_DISCARD inline T Offset(U* anyPointer, V howManyBytes) PDB_NO_EXCEPT
 		{
-			T as_T;
-			U* as_U_ptr;
-			char* as_char_ptr;
-		};
+			static_assert(std::is_pointer<T>::value == true, "Type T must be a pointer type.");
+			static_assert(std::is_const<typename std::remove_pointer<T>::type>::value == std::is_const<U>::value, "Wrong constness.");
 
-		as_U_ptr = anyPointer;
-		as_char_ptr += howManyBytes;
+			union
+			{
+				T as_T;
+				U* as_U_ptr;
+				char* as_char_ptr;
+			};
 
-		return as_T;
+			as_U_ptr = anyPointer;
+			as_char_ptr += howManyBytes;
+
+			return as_T;
+		}
 	}
 }

--- a/src/PDB_CoalescedMSFStream.cpp
+++ b/src/PDB_CoalescedMSFStream.cpp
@@ -54,17 +54,17 @@ PDB::CoalescedMSFStream::CoalescedMSFStream(const void* data, uint32_t blockSize
 		// instead, we directly point into the memory-mapped file at the correct offset.
 		const uint32_t index = blockIndices[0];
 		const size_t fileOffset = PDB::ConvertBlockIndexToFileOffset(index, blockSize);
-		m_data = Pointer::Offset<const std::byte*>(data, fileOffset);
+		m_data = Pointer::Offset<const std::uint8_t*>(data, fileOffset);
 	}
 	else
 	{
 		const uint32_t blockSizeLog2 = BitUtil::FindFirstSetBit(blockSize);
 
 		// slower path, we need to copy disjunct blocks into our own data array, block by block
-		m_ownedData = PDB_NEW_ARRAY(std::byte, streamSize);
+		m_ownedData = PDB_NEW_ARRAY(std::uint8_t, streamSize);
 		m_data = m_ownedData;
 
-		std::byte* destination = m_ownedData;
+		std::uint8_t* destination = m_ownedData;
 
 		// copy full blocks first
 		const uint32_t fullBlockCount = streamSize / blockSize;
@@ -108,12 +108,12 @@ PDB::CoalescedMSFStream::CoalescedMSFStream(const DirectMSFStream& directStream,
 	{
 		// fast path, all block indices inside the direct stream from (data + offset) to (data + offset + size) are contiguous
 		const size_t offsetWithinData = directStream.GetDataOffsetForOffset(offset);
-		m_data = Pointer::Offset<const std::byte*>(directStream.GetData(), offsetWithinData);
+		m_data = Pointer::Offset<const std::uint8_t*>(directStream.GetData(), offsetWithinData);
 	}
 	else
 	{
 		// slower path, we need to copy from disjunct blocks, which is performed by the direct stream
-		m_ownedData = PDB_NEW_ARRAY(std::byte, size);
+		m_ownedData = PDB_NEW_ARRAY(std::uint8_t, size);
 		m_data = m_ownedData;
 
 		directStream.ReadAtOffset(m_ownedData, size, offset);

--- a/src/PDB_CoalescedMSFStream.h
+++ b/src/PDB_CoalescedMSFStream.h
@@ -43,11 +43,11 @@ namespace PDB
 
 	private:
 		// contiguous, coalesced data, can be null
-		std::byte* m_ownedData;
+		std::uint8_t* m_ownedData;
 
 		// either points to the owned data that has been copied from disjunct blocks, or points to the
 		// memory-mapped data directly in case all stream blocks are contiguous.
-		const std::byte* m_data;
+		const std::uint8_t* m_data;
 		size_t m_size;
 
 		PDB_DISABLE_COPY(CoalescedMSFStream);

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -14,7 +14,7 @@ namespace PDB
 		// https://github.com/microsoft/microsoft-pdb/blob/master/PDB/dbi/dbi.h#L124
 		struct StreamHeader
 		{
-			static inline constexpr const uint32_t Signature = 0xffffffffu;
+			static constexpr const uint32_t Signature = 0xffffffffu;
 
 			enum class PDB_NO_DISCARD Version : uint32_t
 			{
@@ -50,7 +50,7 @@ namespace PDB
 		// https://llvm.org/docs/PDB/DbiStream.html#optional-debug-header-stream
 		struct DebugHeader
 		{
-			static inline constexpr const uint16_t InvalidStreamIndex = 0xFFFFu;
+			static constexpr const uint16_t InvalidStreamIndex = 0xFFFFu;
 
 			uint16_t fpoDataStreamIndex;						// IMAGE_DEBUG_TYPE_FPO
 			uint16_t exceptionDataStreamIndex;					// IMAGE_DEBUG_TYPE_EXCEPTION

--- a/src/PDB_GlobalSymbolStream.h
+++ b/src/PDB_GlobalSymbolStream.h
@@ -11,9 +11,12 @@ namespace PDB
 	class RawFile;
 	struct HashRecord;
 
-	namespace CodeView::DBI
+	namespace CodeView
 	{
-		struct Record;
+		namespace DBI
+		{
+			struct Record;
+		}		
 	}
 
 

--- a/src/PDB_PublicSymbolStream.h
+++ b/src/PDB_PublicSymbolStream.h
@@ -11,9 +11,12 @@ namespace PDB
 	class RawFile;
 	struct HashRecord;
 
-	namespace CodeView::DBI
+	namespace CodeView
 	{
-		struct Record;
+		namespace DBI
+		{
+			struct Record;
+		}		
 	}
 
 

--- a/src/PDB_Types.h
+++ b/src/PDB_Types.h
@@ -42,7 +42,7 @@ namespace PDB
 	struct PDB_NO_DISCARD SuperBlock
 	{
 		// https://github.com/Microsoft/microsoft-pdb/blob/master/PDB/msf/msf.cpp#L962
-		static inline constexpr const char MAGIC[30u] = "Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53";
+		static constexpr const char MAGIC[30u] = "Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53";
 
 		char fileMagic[30u];
 		char padding[2u];
@@ -136,8 +136,8 @@ namespace PDB
 	// https://github.com/Microsoft/microsoft-pdb/blob/master/PDB/dbi/gsi.h#L62
 	struct HashTableHeader
 	{
-		static inline constexpr const uint32_t Signature = 0xffffffffu;
-		static inline constexpr const uint32_t Version = 0xeffe0000u + 19990810u;
+		static constexpr const uint32_t Signature = 0xffffffffu;
+		static constexpr const uint32_t Version = 0xeffe0000u + 19990810u;
 
 		uint32_t signature;
 		uint32_t version;


### PR DESCRIPTION
As discussed, this compiles under VS2015, 2017, 2019, and 2022 as C++11, though there is a link error related to the usage of `_BitScanForward` under 2015 and 2017.

- Removed nested namespaces
- PDB_NO_DISCARD is now only defined if the compiler & std level supports it
- Replaced usages of std::byte with std::uint8_t
- Removed inline from static const variables
