### PR TITLE
Add InfoStream::GetHeader() accessor

### DIFF
--- a/src/PDB_InfoStream.h
+++ b/src/PDB_InfoStream.h
@@ -22,6 +22,8 @@ namespace PDB
 
 		PDB_DEFAULT_MOVE(InfoStream);
 
+		const Header* GetHeader() const { return m_header; }
+
 	private:
 		CoalescedMSFStream m_stream;
 		const Header* m_header;


### PR DESCRIPTION
Add accessor to retrieve the "age" and "guid" of a pdb file.

Usage:
PDB::RawFile raw_pdb_file = PDB::CreateRawFile(raw_pdb_file_handle.baseAddress);
PDB::InfoStream pdb_info_stream(raw_pdb_file_);
age_ = pdb_info_stream.GetHeader()->age;
guid_ = pdb_info_stream.GetHeader()->guid;