### PR TITLE
fix build on Linux

### DIFF
--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "Examples_PCH.h"
 #include "ExampleTimedScope.h"
 #include "PDB_RawFile.h"


### PR DESCRIPTION
strnlen() is in <cstring>, POSIX.1-2008

/tmp/raw_pdb/src/Examples/ExampleTypes.cpp:681:22: error: ‘strnlen’ was not declared in this scope
  681 |                 i += strnlen(leafName, maximumSize - i - 1) + 1;
      |                      ^~~~~~~