### PR TITLE
#include <intrin.h> on Windows.

### DIFF
--- a/src/Foundation/PDB_BitUtil.h
+++ b/src/Foundation/PDB_BitUtil.h
@@ -8,6 +8,11 @@
 #include <type_traits>
 #include "PDB_DisableWarningsPop.h"
 
+#ifdef _WIN32
+#include <intrin.h>
+#	pragma intrinsic(_BitScanForward)
+#endif
+
 
 namespace PDB
 {


### PR DESCRIPTION
Fixes compile error when building with Mingw-w64

Reference: https://docs.microsoft.com/en-us/cpp/intrinsics/bitscanforward-bitscanforward64