### PR TITLE
Examples fixes

### DIFF
--- a/src/Examples/ExampleFunctionSymbols.cpp
+++ b/src/Examples/ExampleFunctionSymbols.cpp
@@ -210,6 +210,7 @@ void ExampleFunctionSymbols(const PDB::RawFile& rawPdbFile, const PDB::DBIStream
 
 			const FunctionSymbol& nextSymbol = functionSymbols[i + 1u];
 			const size_t size = nextSymbol.rva - currentSymbol.rva;
+			(void)size; // unused
 			++foundCount;
 		}
 

--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
 {
 	if (argc != 2)
 	{
-		printf("Incorrect usage\n");
+		printf("Usage: Examples <PDB path>\nError: Incorrect usage");
 
 		return 1;
 	}

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -1,12 +1,12 @@
-#include <cstring>
-#include <cinttypes>
-
 #include "Examples_PCH.h"
 #include "ExampleTimedScope.h"
 #include "PDB_RawFile.h"
 #include "Foundation/PDB_Assert.h"
 #include "PDB_DBIStream.h"
 #include "PDB_TPIStream.h"
+
+#include <cstring>
+#include <cinttypes>
 
 #pragma warning(push)
 #pragma warning(disable : 4061)

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -177,11 +177,13 @@ const char* GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeIndex, uin
 		switch (typeRecord->header.kind)
 		{
 		case PDB::CodeView::TPI::TypeRecordKind::LF_MODIFIER:
-			*modifierRecord = typeRecord;
+			if(modifierRecord)
+				*modifierRecord = typeRecord;
 			return GetTypeName(tpiStream, typeRecord->data.LF_MODIFIER.type, pointerLevel, nullptr, nullptr);
 		case PDB::CodeView::TPI::TypeRecordKind::LF_POINTER:
 			++pointerLevel;
-			*referencedType = typeRecord;
+			if(referencedType)
+				*referencedType = typeRecord;
 			if (typeRecord->data.LF_POINTER.utype >= typeIndexBegin)
 			{
 				underlyingType = tpiStream.GetTypeRecord(typeRecord->data.LF_POINTER.utype);


### PR DESCRIPTION
1. Fix null pointer deference which result in a crash.
2. Fix compiler warnings in VS2022.
3. Make "Incorrect usage" error actionable.
