### PR TITLE
Compile & crash fixes

### DIFF
--- a/src/Foundation/PDB_Macros.h
+++ b/src/Foundation/PDB_Macros.h
@@ -11,7 +11,7 @@
 // ------------------------------------------------------------------------------------------------
 
 // Indicates to the compiler that the function returns an object that is not aliased by any other pointers.
-#if PDB_COMPILER_MSVC or PDB_COMPILER_CLANG
+#if PDB_COMPILER_MSVC || PDB_COMPILER_CLANG
 #	define PDB_NO_ALIAS								__declspec(restrict)
 #else
 #	define PDB_NO_ALIAS								__restrict

--- a/src/PDB_CoalescedMSFStream.cpp
+++ b/src/PDB_CoalescedMSFStream.cpp
@@ -139,9 +139,15 @@ PDB::CoalescedMSFStream::CoalescedMSFStream(const DirectMSFStream& directStream,
 	, m_data(nullptr)
 	, m_size(size)
 {
-	const uint32_t* const blockIndicesForOffset = directStream.GetBlockIndicesForOffset(offset);
+	size_t offsetWithinBlock;
+	const uint32_t* const blockIndicesForOffset = directStream.GetBlockIndicesForOffset(offset, offsetWithinBlock);
 
-	if (AreBlockIndicesContiguous(blockIndicesForOffset, directStream.GetBlockSize(), size))
+	// Note: we need to add the offset within the block to the size of the stream to determine if the block
+	// indices are contiguous. This is needed to deal with the case where reading the requested number of bytes
+	// from the specified offset would cross a block boundary. For example, if the offset within the block is
+	// 64 and we want to read 4096 bytes with a block size of 4096, we need to consider *two* block indices,
+	// not *one*, even though 4096 / 4096 = 1.
+	if (AreBlockIndicesContiguous(blockIndicesForOffset, directStream.GetBlockSize(), offsetWithinBlock + size))
 	{
 		// fast path, all block indices inside the direct stream from (data + offset) to (data + offset + size) are contiguous
 		const size_t offsetWithinData = directStream.GetDataOffsetForOffset(offset);

--- a/src/PDB_DBIStream.cpp
+++ b/src/PDB_DBIStream.cpp
@@ -62,6 +62,14 @@ namespace
 
 	// ------------------------------------------------------------------------------------------------
 	// ------------------------------------------------------------------------------------------------
+	PDB_NO_DISCARD static inline uint32_t HasDebugHeaderSubstream(const PDB::DBI::StreamHeader& dbiHeader) PDB_NO_EXCEPT
+	{
+		return dbiHeader.optionalDebugHeaderSize != 0;
+	}
+
+
+	// ------------------------------------------------------------------------------------------------
+	// ------------------------------------------------------------------------------------------------
 	PDB_NO_DISCARD static inline uint32_t GetDebugHeaderSubstreamOffset(const PDB::DBI::StreamHeader& dbiHeader) PDB_NO_EXCEPT
 	{
 		return GetECSubstreamOffset(dbiHeader) + dbiHeader.ecSize;
@@ -122,6 +130,12 @@ PDB_NO_DISCARD PDB::DBIStream PDB::CreateDBIStream(const RawFile& file) PDB_NO_E
 // ------------------------------------------------------------------------------------------------
 PDB_NO_DISCARD PDB::ErrorCode PDB::DBIStream::HasValidImageSectionStream(const RawFile& /* file */) const PDB_NO_EXCEPT
 {
+	// The debug header stream is optional. If it's not there, we can't get the image section stream either.
+	if (!HasDebugHeaderSubstream(m_header))
+	{
+		return ErrorCode::InvalidStreamIndex;
+	}
+
 	// find the debug header sub-stream
 	const uint32_t debugHeaderOffset = GetDebugHeaderSubstreamOffset(m_header);
 	const DBI::DebugHeader& debugHeader = m_stream.ReadAtOffset<DBI::DebugHeader>(debugHeaderOffset);

--- a/src/PDB_DirectMSFStream.cpp
+++ b/src/PDB_DirectMSFStream.cpp
@@ -95,9 +95,10 @@ void PDB::DirectMSFStream::ReadAtOffset(void* destination, size_t size, size_t o
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-PDB_NO_DISCARD const uint32_t* PDB::DirectMSFStream::GetBlockIndicesForOffset(uint32_t offset) const PDB_NO_EXCEPT
+PDB_NO_DISCARD const uint32_t* PDB::DirectMSFStream::GetBlockIndicesForOffset(uint32_t offset, size_t& offsetWithinBlock) const PDB_NO_EXCEPT
 {
 	const size_t firstBlockIndex = offset >> m_blockSizeLog2;
+	offsetWithinBlock = offset & (m_blockSize - 1u);
 
 	return m_blockIndices + firstBlockIndex;
 }

--- a/src/PDB_DirectMSFStream.h
+++ b/src/PDB_DirectMSFStream.h
@@ -53,7 +53,7 @@ namespace PDB
 		friend class CoalescedMSFStream;
 
 		// Returns the block indices that correspond to the given offset.
-		PDB_NO_DISCARD const uint32_t* GetBlockIndicesForOffset(uint32_t offset) const PDB_NO_EXCEPT;
+		PDB_NO_DISCARD const uint32_t* GetBlockIndicesForOffset(uint32_t offset, size_t& offsetWithinBlock) const PDB_NO_EXCEPT;
 
 		// Returns the offset into the data that corresponds to the given offset.
 		PDB_NO_DISCARD size_t GetDataOffsetForOffset(uint32_t offset) const PDB_NO_EXCEPT;


### PR DESCRIPTION
- Fixed compile issue (incorrect preprocessor test in PDB_Macros.h)
- Fixed crash in `DBIStream::HasValidImageSectionStream`: the `DebugHeaderSubstream` is optional. If it's missing, `HasValidImageSectionStream` would crash because it would try to read past the end of the buffer.
- Fixed crash when iterating through modules in the `ModuleInfoStream`, caused by garbage data in the Modules list. The root cause was an issue in `CoalescedMSFStream`: the `AreBlockIndicesContiguous` test could incorrectly return true when reading <= `blockSize` bytes from a non-zero `offset` in the block. This would result in a read that *should* have been reading from multiple disjoint blocks to instead read past the end of the block that the `offset` was in, resulting in `offset` bytes of garbage data being read at the end.