### PR TITLE
Include 'cstring' header

### DIFF
--- a/src/Examples/ExampleLines.cpp
+++ b/src/Examples/ExampleLines.cpp
@@ -8,6 +8,7 @@
 #include "PDB_DBIStream.h"
 #include "PDB_InfoStream.h"
 
+#include <cstring>
 
 namespace
 {


### PR DESCRIPTION
Adding `#include <cstring>` to `src/Examples/ExampleLines.cpp`. Fixes issue #43.