### PR TITLE
Function variables support and example

### DIFF
--- a/build/Examples.vcxproj
+++ b/build/Examples.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\Examples\ExampleContributions.cpp" />
     <ClCompile Include="..\src\Examples\ExampleFunctionSymbols.cpp" />
+    <ClCompile Include="..\src\Examples\ExampleFunctionVariables.cpp" />
     <ClCompile Include="..\src\Examples\ExampleLines.cpp" />
     <ClCompile Include="..\src\Examples\ExampleMain.cpp" />
     <ClCompile Include="..\src\Examples\ExampleMemoryMappedFile.cpp" />

--- a/build/Examples.vcxproj.filters
+++ b/build/Examples.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="..\src\Examples\ExampleLines.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\Examples\ExampleFunctionVariables.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\Examples\ExampleMemoryMappedFile.h">

--- a/src/Examples/CMakeLists.txt
+++ b/src/Examples/CMakeLists.txt
@@ -3,6 +3,7 @@ project(Examples)
 set(SOURCES
 	ExampleContributions.cpp
 	ExampleFunctionSymbols.cpp
+	ExampleFunctionVariables.cpp
 	ExampleLines.cpp
 	ExampleMain.cpp
 	ExampleMemoryMappedFile.cpp

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -190,14 +190,23 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				{
 					printf("%*sS_INLINEES: Count %u\n", blockIndent * 4, "", data.S_INLINEES.count);
 				}
-				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_LDATA32)
+				else if (kind == SymbolRecordKind::S_LDATA32)
 				{
 					if (blockIndent > 0)
 					{
-						const std::string typeName = GetTypeName(tpiStream, record->data.S_CONSTANT.typeIndex);
+						const std::string typeName = GetTypeName(tpiStream, record->data.S_LDATA32.typeIndex);
 						printf("%*sS_LDATA32: '%s' -> '%s'\n", blockIndent * 4, "", record->data.S_LDATA32.name, typeName.c_str());
 					}
 				}
+				else if (kind == SymbolRecordKind::S_LTHREAD32)
+				{
+					if (blockIndent > 0)
+					{
+						const std::string typeName = GetTypeName(tpiStream, record->data.S_LTHREAD32.typeIndex);
+						printf("%*sS_LTHREAD32: '%s' -> '%s'\n", blockIndent * 4, "", data.S_LTHREAD32.name, typeName.c_str());
+					}
+				}
+
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_UDT)
 				{
 					const std::string typeName = GetTypeName(tpiStream, record->data.S_UDT.typeIndex);
@@ -280,7 +289,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				{
 					if (blockIndent != 0)
 					{
-						PDB_ASSERT(false, "Unhandled record kind 0x%X\n", record->header.kind);
+						PDB_ASSERT(false, "Unhandled record kind 0x%X with block identation %u\n", record->header.kind, blockIndent);
 					}
 				}
 

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -9,46 +9,12 @@
 
 namespace
 {
-	struct FunctionRecords
-	{
-		size_t index;
-		size_t size;
-	};
-
-	struct FunctionRecord
-	{
-		enum class Kind : uint8_t
-		{
-			None = 0,
-			Block = 1,
-			Variable = 2
-		};
-
-		Kind kind;
-
-		union
-		{
-			struct
-			{
-				size_t nameIndex;
-				size_t typeIndex;
-			} variable;
-
-			struct
-			{
-				FunctionRecords records;
-			} block;
-		};
-	};
-
 	struct FunctionSymbol
 	{
 		std::string name;
 		uint32_t rva;
 		uint32_t size;
 		const PDB::CodeView::DBI::Record* frameProc;
-
-		FunctionRecords records;
 	};
 }
 
@@ -143,76 +109,76 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				{
 					PDB_ASSERT(blockLevel > 0, "BlockIndent for S_END is 0");
 					blockLevel--;
-					printf("%*sS_END\n", blockLevel * 4, "");
+					Printf(blockLevel, "S_END\n");
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_BLOCK32)
 				{
 					const uint32_t offset = imageSectionStream.ConvertSectionOffsetToRVA(data.S_BLOCK32.section, data.S_BLOCK32.offset);
 
-					printf("%*sS_BLOCK32: '%s' | Code Offset 0x%X\n", blockLevel*4, "", data.S_BLOCK32.name, offset);
+					Printf(blockLevel, "S_BLOCK32: '%s' | Code Offset 0x%X\n", data.S_BLOCK32.name, offset);
 					blockLevel++;
 				}
 				else if (kind == SymbolRecordKind::S_LABEL32)
 				{
-					printf("%*sS_LABEL32: '%s' | Offset 0x%X\n", blockLevel * 4, "", data.S_LABEL32.name, data.S_LABEL32.offset);
+					Printf(blockLevel, "S_LABEL32: '%s' | Offset 0x%X\n", data.S_LABEL32.name, data.S_LABEL32.offset);
 				}
 				else if(kind == SymbolRecordKind::S_CONSTANT)
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_CONSTANT.typeIndex);
 
-					printf("%*sS_CONSTANT: '%s' -> '%s' | Value 0x%X\n", blockLevel*4, "", typeName.c_str(), data.S_CONSTANT.name, data.S_CONSTANT.value);
+					Printf(blockLevel, "S_CONSTANT: '%s' -> '%s' | Value 0x%X\n", typeName.c_str(), data.S_CONSTANT.name, data.S_CONSTANT.value);
 				}
 				else if(kind == SymbolRecordKind::S_LOCAL)
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_LOCAL.typeIndex);
-					printf("%*sS_LOCAL: '%s' -> '%s'\n", blockLevel*4, "", typeName.c_str(), data.S_LOCAL.name);
+					Printf(blockLevel, "S_LOCAL: '%s' -> '%s'\n", typeName.c_str(), data.S_LOCAL.name);
 				}
 				else if (kind == SymbolRecordKind::S_DEFRANGE_REGISTER)
 				{
-					printf("%*sS_DEFRANGE_REGISTER: Register 0x%X\n", blockLevel * 4, "", data.S_DEFRANGE_REGISTER.reg);
+					Printf(blockLevel, "S_DEFRANGE_REGISTER: Register 0x % X\n", data.S_DEFRANGE_REGISTER.reg);
 				}
 				else if(kind == SymbolRecordKind::S_DEFRANGE_FRAMEPOINTER_REL)
 				{
-					printf("%*sS_DEFRANGE_FRAMEPOINTER_REL: <TODO>\n", blockLevel * 4, "");
+					Printf(blockLevel, "S_DEFRANGE_FRAMEPOINTER_REL: <TODO>\n");
 				}
 				else if(kind == SymbolRecordKind::S_DEFRANGE_SUBFIELD_REGISTER)
 				{
-					printf("%*sS_DEFRANGE_SUBFIELD_REGISTER: <TODO>\n", blockLevel * 4, "");
+					Printf(blockLevel, "S_DEFRANGE_SUBFIELD_REGISTER: <TODO>\n");
 				}
 				else if (kind == SymbolRecordKind::S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE)
 				{
-					printf("%*sS_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE: Offset 0x%X\n", blockLevel * 4, "", data.S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE.offsetFramePointer);
+					Printf(blockLevel, "S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE: Offset 0x%X\n", data.S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE.offsetFramePointer);
 				}
 				else if (kind == SymbolRecordKind::S_DEFRANGE_REGISTER_REL)
 				{
-					printf("%*sS_DEFRANGE_REGISTER_REL: <TODO>\n", blockLevel * 4, "");
+					Printf(blockLevel, "S_DEFRANGE_REGISTER_REL: <TODO>\n");
 				}
 				else if(kind == SymbolRecordKind::S_FILESTATIC)
 				{
-					printf("%*sS_FILESTATIC: '%s'\n", blockLevel * 4, "", data.S_FILESTATIC.name);
+					Printf(blockLevel, "S_FILESTATIC: '%s'\n", data.S_FILESTATIC.name);
 				}
 				else if (kind == SymbolRecordKind::S_INLINESITE)
 				{
-					printf("%*sS_INLINESITE: Parent 0x%X\n", blockLevel * 4, "", data.S_INLINESITE.parent);
+					Printf(blockLevel, "S_INLINESITE: Parent 0x % X\n", data.S_INLINESITE.parent);
 					blockLevel++;
 				}
 				else if (kind == SymbolRecordKind::S_INLINESITE_END)
 				{
 					PDB_ASSERT(blockLevel > 0, "BlockIndent for S_INLINESITE_END is 0");
 					blockLevel--;					
-					printf("%*sS_INLINESITE_END:\n", blockLevel * 4, "");
+					Printf(blockLevel, "S_INLINESITE_END:\n");
 				}
 				else if (kind == SymbolRecordKind::S_CALLEES)
 				{
-					printf("%*sS_CALLEES: Count %u\n", blockLevel * 4, "", data.S_CALLEES.count);
+					Printf(blockLevel, "S_CALLEES: Count %u\n", data.S_CALLEES.count);
 				}
 				else if (kind == SymbolRecordKind::S_CALLERS)
 				{
-					printf("%*sS_CALLERS: Count %u\n", blockLevel * 4, "", data.S_CALLERS.count);
+					Printf(blockLevel, "S_CALLERS: Count %u\n", data.S_CALLERS.count);
 				}
 				else if (kind == SymbolRecordKind::S_INLINEES)
 				{
-					printf("%*sS_INLINEES: Count %u\n", blockLevel * 4, "", data.S_INLINEES.count);
+					Printf(blockLevel, "S_INLINEES: Count %u\n", data.S_INLINEES.count);
 				}
 				else if (kind == SymbolRecordKind::S_LDATA32)
 				{
@@ -222,7 +188,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 						if (data.S_LDATA32.typeIndex != 0) // PDB::CodeView::TPI::TypeIndexKind::T_NOTYPE)
 						{
 							const std::string typeName = GetVariableTypeName(tpiStream, data.S_LDATA32.typeIndex);
-							printf("%*sS_LDATA32: '%s' -> '%s'\n", blockLevel * 4, "", data.S_LDATA32.name, typeName.c_str());
+							Printf(blockLevel, "S_LDATA32: '%s' -> '%s'\n", data.S_LDATA32.name, typeName.c_str());
 						}						
 					}
 				}
@@ -231,7 +197,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 					if (blockLevel > 0)
 					{
 						const std::string typeName = GetVariableTypeName(tpiStream, data.S_LTHREAD32.typeIndex);
-						printf("%*sS_LTHREAD32: '%s' -> '%s'\n", blockLevel * 4, "", data.S_LTHREAD32.name, typeName.c_str());
+						Printf(blockLevel, "S_LTHREAD32: '%s' -> '%s'\n", data.S_LTHREAD32.name, typeName.c_str());
 					}
 				}
 
@@ -239,27 +205,27 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_UDT.typeIndex);
 
-					printf("%*sS_UDT: '%s' -> '%s'\n", blockLevel * 4, "", data.S_UDT.name, typeName.c_str());
+					Printf(blockLevel, "S_UDT: '%s' -> '%s'\n", data.S_UDT.name, typeName.c_str());
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_REGREL32)
 				{
-					std::string typeName = GetVariableTypeName(tpiStream, data.S_REGREL32.typeIndex);
+					const std::string typeName = GetVariableTypeName(tpiStream, data.S_REGREL32.typeIndex);
 	
-					printf("%*sS_REGREL32: '%s' -> '%s' | Register %i | Register Offset 0x%X\n", blockLevel * 4, "", data.S_REGREL32.name, typeName.c_str(), data.S_REGREL32.reg, data.S_REGREL32.offset);
+					Printf(blockLevel, "S_REGREL32: '%s' -> '%s' | Register %i | Register Offset 0x%X\n", data.S_REGREL32.name, typeName.c_str(), data.S_REGREL32.reg, data.S_REGREL32.offset);
 				}
 				else if(kind == SymbolRecordKind::S_FRAMECOOKIE)
 				{
-					printf("%*sS_FRAMECOOKIE Offset 0x%X | Register %u | Type %u\n", blockLevel * 4, "", data.S_FRAMECOOKIE.offset, data.S_FRAMECOOKIE.reg, data.S_FRAMECOOKIE.cookietype);
+					Printf(blockLevel, "S_FRAMECOOKIE: Offset 0x%X | Register %u | Type %u\n", data.S_FRAMECOOKIE.offset, data.S_FRAMECOOKIE.reg, data.S_FRAMECOOKIE.cookietype);
 				}
 				else if(kind == SymbolRecordKind::S_CALLSITEINFO)
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_CALLSITEINFO.typeIndex);
-					printf("%*sS_CALLSITEINFO '%s' | Offset 0x%X | Section %u\n", blockLevel * 4, "" , typeName.c_str(), data.S_CALLSITEINFO.offset, data.S_CALLSITEINFO.section);
+					Printf(blockLevel, "S_CALLSITEINFO: '%s' | Offset 0x%X | Section %u\n", typeName.c_str(), data.S_CALLSITEINFO.offset, data.S_CALLSITEINFO.section);
 				}
 				else if(kind == SymbolRecordKind::S_HEAPALLOCSITE)
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_HEAPALLOCSITE.typeIndex);
-					Printf(blockLevel, "S_HEAPALLOCSITE '%s' | Offset 0x%X | Section %u | Instruction Length %u\n", typeName.c_str(), data.S_HEAPALLOCSITE.offset, data.S_HEAPALLOCSITE.section, data.S_HEAPALLOCSITE.instructionLength);
+					Printf(blockLevel, "S_HEAPALLOCSITE: '%s' | Offset 0x%X | Section %u | Instruction Length %u\n", typeName.c_str(), data.S_HEAPALLOCSITE.offset, data.S_HEAPALLOCSITE.section, data.S_HEAPALLOCSITE.instructionLength);
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_FRAMEPROC)
 				{
@@ -335,7 +301,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 					blockLevel++;
 				}
 
-				functionSymbols.push_back(FunctionSymbol{ name, rva, size, nullptr, {0, 0} });
+				functionSymbols.push_back(FunctionSymbol{ name, rva, size, nullptr });
 				seenFunctionRVAs.emplace(rva);
 			});
 		}
@@ -383,7 +349,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 
 			// this is a new function symbol, so store it.
 			// note that we don't know its size yet.
-			functionSymbols.push_back(FunctionSymbol{ record->data.S_PUB32.name, rva, 0u, nullptr, {0, 0} });
+			functionSymbols.push_back(FunctionSymbol{ record->data.S_PUB32.name, rva, 0u, nullptr});
 		}
 
 		scope.Done(count);

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -223,11 +223,12 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if(kind == SymbolRecordKind::S_FRAMECOOKIE)
 				{
-					printf("%*sS_FRAMECOOKIE <TODO>\n", blockIndent * 4, "");
+					printf("%*sS_FRAMECOOKIE Offset 0x%X | Register %u | Type %u\n", blockIndent * 4, "", data.S_FRAMECOOKIE.offset, data.S_FRAMECOOKIE.reg, data.S_FRAMECOOKIE.cookietype);
 				}
 				else if(kind == SymbolRecordKind::S_CALLSITEINFO)
 				{
-					printf("%*sS_CALLSITEINFO <TODO>\n", blockIndent * 4, "");
+					const std::string typeName = GetTypeName(tpiStream, data.S_CALLSITEINFO.typeIndex);
+					printf("%*sS_CALLSITEINFO '%s' | Offset 0x%X | Section %u\n", blockIndent * 4, "" , typeName.c_str(), data.S_CALLSITEINFO.offset, data.S_CALLSITEINFO.section);
 				}
 				else if(kind == SymbolRecordKind::S_HEAPALLOCSITE)
 				{

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -296,7 +296,10 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 
 				printf("%*sFunction: '%s' | RVA 0x%X\n", blockIndent*4, "", name, rva);
 
-				blockIndent++;
+				if (kind != SymbolRecordKind::S_TRAMPOLINE)
+				{
+					blockIndent++;
+				}
 
 				functionSymbols.push_back(FunctionSymbol{ name, rva, size, nullptr, {0, 0} });
 				seenFunctionRVAs.emplace(rva);

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -147,6 +147,49 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				{
 					printf("%*sS_DEFRANGE_REGISTER: Register 0x%X\n", blockIndent * 4, "", record->data.S_DEFRANGE_REGISTER.reg);
 				}
+				else if(kind == SymbolRecordKind::S_DEFRANGE_FRAMEPOINTER_REL)
+				{
+					printf("%*sS_DEFRANGE_FRAMEPOINTER_REL: <TODO>\n", blockIndent * 4, "");
+				}
+				else if(kind == SymbolRecordKind::S_DEFRANGE_SUBFIELD_REGISTER)
+				{
+					printf("%*sS_DEFRANGE_SUBFIELD_REGISTER: <TODO>\n", blockIndent * 4, "");
+				}
+				else if (kind == SymbolRecordKind::S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE)
+				{
+					printf("%*sS_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE: Offset 0x%X\n", blockIndent * 4, "", record->data.S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE.offsetFramePointer);
+				}
+				else if (kind == SymbolRecordKind::S_DEFRANGE_REGISTER_REL)
+				{
+					printf("%*sS_DEFRANGE_REGISTER_REL: <TODO>\n", blockIndent * 4, "");
+				}
+				else if(kind == SymbolRecordKind::S_FILESTATIC)
+				{
+					printf("%*sS_FILESTATIC: '%s'\n", blockIndent * 4, "", data.S_FILESTATIC.name);
+				}
+				else if (kind == SymbolRecordKind::S_INLINESITE)
+				{
+					printf("%*sS_INLINESITE: Parent 0x%X\n", blockIndent * 4, "", data.S_INLINESITE.parent);
+					blockIndent++;
+				}
+				else if (kind == SymbolRecordKind::S_INLINESITE_END)
+				{
+					PDB_ASSERT(blockIndent > 0, "BlockIndent for S_INLINESITE_END is 0");
+					blockIndent--;					
+					printf("%*sS_INLINESITE_END:\n", blockIndent * 4, "");
+				}
+				else if (kind == SymbolRecordKind::S_CALLEES)
+				{
+					printf("%*sS_CALLEES: Count %u\n", blockIndent * 4, "", data.S_CALLEES.count);
+				}
+				else if (kind == SymbolRecordKind::S_CALLERS)
+				{
+					printf("%*sS_CALLERS: Count %u\n", blockIndent * 4, "", data.S_CALLERS.count);
+				}
+				else if (kind == SymbolRecordKind::S_INLINEES)
+				{
+					printf("%*sS_INLINEES: Count %u\n", blockIndent * 4, "", data.S_INLINEES.count);
+				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_LDATA32)
 				{
 					if (blockIndent > 0)

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -294,7 +294,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 
 				PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
 
-				printf("%*sFunction: '%s' | RVA 0x%X\n", blockLevel*4, "", name, rva);
+				Printf(blockLevel, "Function: '%s' | RVA 0x%X\n", name, rva);
 
 				if (kind != SymbolRecordKind::S_TRAMPOLINE)
 				{

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -131,11 +131,20 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if(kind == SymbolRecordKind::S_DEFRANGE_FRAMEPOINTER_REL)
 				{
-					Printf(blockLevel, "S_DEFRANGE_FRAMEPOINTER_REL: <TODO>\n");
+					Printf(blockLevel, "S_DEFRANGE_FRAMEPOINTER_REL: Frame Pointer Offset 0x%X | Range Start 0x%X | Range Section Start 0x%X | Range Length %u\n", 
+							data.S_DEFRANGE_FRAMEPOINTER_REL.offsetFramePointer, 
+							data.S_DEFRANGE_FRAMEPOINTER_REL.range.offsetStart, 
+							data.S_DEFRANGE_FRAMEPOINTER_REL.range.isectionStart, 
+							data.S_DEFRANGE_FRAMEPOINTER_REL.range.length);
 				}
 				else if(kind == SymbolRecordKind::S_DEFRANGE_SUBFIELD_REGISTER)
 				{
-					Printf(blockLevel, "S_DEFRANGE_SUBFIELD_REGISTER: <TODO>\n");
+					Printf(blockLevel, "S_DEFRANGE_SUBFIELD_REGISTER: Register %u | Parent offset 0x%X | Range Start 0x%X | Range Section Start 0x%X | Range Length %u\n", 
+						data.S_DEFRANGE_SUBFIELD_REGISTER.reg,
+						data.S_DEFRANGE_SUBFIELD_REGISTER.offsetParent,
+						data.S_DEFRANGE_SUBFIELD_REGISTER.range.offsetStart, 
+						data.S_DEFRANGE_SUBFIELD_REGISTER.range.isectionStart, 
+						data.S_DEFRANGE_SUBFIELD_REGISTER.range.length);
 				}
 				else if (kind == SymbolRecordKind::S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE)
 				{
@@ -143,7 +152,14 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if (kind == SymbolRecordKind::S_DEFRANGE_REGISTER_REL)
 				{
-					Printf(blockLevel, "S_DEFRANGE_REGISTER_REL: <TODO>\n");
+					Printf(blockLevel, "S_DEFRANGE_REGISTER_REL: Base Register %u | Parent offset 0x%X | Base Register Offset 0x%X | Range Start 0x%X | Range Section Start 0x%X | Range Length %u\n",
+						data.S_DEFRANGE_REGISTER_REL.baseRegister,
+						data.S_DEFRANGE_REGISTER_REL.offsetParent,
+						data.S_DEFRANGE_REGISTER_REL.offsetBasePointer,
+						data.S_DEFRANGE_REGISTER_REL.offsetParent,
+						data.S_DEFRANGE_REGISTER_REL.range.offsetStart, 
+						data.S_DEFRANGE_REGISTER_REL.range.isectionStart, 
+						data.S_DEFRANGE_REGISTER_REL.range.length);						
 				}
 				else if(kind == SymbolRecordKind::S_FILESTATIC)
 				{
@@ -156,7 +172,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if (kind == SymbolRecordKind::S_INLINESITE_END)
 				{
-					PDB_ASSERT(blockLevel > 0, "BlockIndent for S_INLINESITE_END is 0");
+					PDB_ASSERT(blockLevel > 0, "Block level for S_INLINESITE_END is 0");
 					blockLevel--;					
 					Printf(blockLevel, "S_INLINESITE_END:\n");
 				}
@@ -202,11 +218,17 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_REGREL32.typeIndex);
 	
-					Printf(blockLevel, "S_REGREL32: '%s' -> '%s' | Register %i | Register Offset 0x%X\n", data.S_REGREL32.name, typeName.c_str(), data.S_REGREL32.reg, data.S_REGREL32.offset);
+					Printf(blockLevel, "S_REGREL32: '%s' -> '%s' | Register %i | Register Offset 0x%X\n", 
+						data.S_REGREL32.name, typeName.c_str(), 
+						data.S_REGREL32.reg, 
+						data.S_REGREL32.offset);
 				}
 				else if(kind == SymbolRecordKind::S_FRAMECOOKIE)
 				{
-					Printf(blockLevel, "S_FRAMECOOKIE: Offset 0x%X | Register %u | Type %u\n", data.S_FRAMECOOKIE.offset, data.S_FRAMECOOKIE.reg, data.S_FRAMECOOKIE.cookietype);
+					Printf(blockLevel, "S_FRAMECOOKIE: Offset 0x%X | Register %u | Type %u\n", 
+						data.S_FRAMECOOKIE.offset, 
+						data.S_FRAMECOOKIE.reg, 
+						data.S_FRAMECOOKIE.cookietype);
 				}
 				else if(kind == SymbolRecordKind::S_CALLSITEINFO)
 				{
@@ -216,11 +238,18 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				else if(kind == SymbolRecordKind::S_HEAPALLOCSITE)
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_HEAPALLOCSITE.typeIndex);
-					Printf(blockLevel, "S_HEAPALLOCSITE: '%s' | Offset 0x%X | Section %u | Instruction Length %u\n", typeName.c_str(), data.S_HEAPALLOCSITE.offset, data.S_HEAPALLOCSITE.section, data.S_HEAPALLOCSITE.instructionLength);
+					Printf(blockLevel, "S_HEAPALLOCSITE: '%s' | Offset 0x%X | Section %u | Instruction Length %u\n", typeName.c_str(), 
+						data.S_HEAPALLOCSITE.offset, 
+						data.S_HEAPALLOCSITE.section, 
+						data.S_HEAPALLOCSITE.instructionLength);
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_FRAMEPROC)
 				{
-					Printf(blockLevel, "S_FRAMEPROC: Size %u | Padding %u | Padding Offset 0x%X | Callee Registers Size %u\n", data.S_FRAMEPROC.cbFrame, data.S_FRAMEPROC.cbPad, data.S_FRAMEPROC.offPad, data.S_FRAMEPROC.cbSaveRegs);
+					Printf(blockLevel, "S_FRAMEPROC: Size %u | Padding %u | Padding Offset 0x%X | Callee Registers Size %u\n", 
+						data.S_FRAMEPROC.cbFrame, 
+						data.S_FRAMEPROC.cbPad, 
+						data.S_FRAMEPROC.offPad, 
+						data.S_FRAMEPROC.cbSaveRegs);
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_THUNK32)
 				{

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -212,6 +212,18 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 
 					printf("%*sS_REGREL32: '%s' -> '%s' | Register %i | Register Offset 0x%X\n", blockIndent * 4, "", data.S_REGREL32.name, typeName.c_str(), data.S_REGREL32.reg, data.S_REGREL32.offset);
 				}
+				else if(kind == SymbolRecordKind::S_FRAMECOOKIE)
+				{
+					printf("%*sS_FRAMECOOKIE <TODO>\n", blockIndent * 4, "");
+				}
+				else if(kind == SymbolRecordKind::S_CALLSITEINFO)
+				{
+					printf("%*sS_CALLSITEINFO <TODO>\n", blockIndent * 4, "");
+				}
+				else if(kind == SymbolRecordKind::S_HEAPALLOCSITE)
+				{
+					printf("%*sS_HEAPALLOCSITE <TODO>\n", blockIndent * 4, "");
+				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_FRAMEPROC)
 				{
 					functionSymbols[functionSymbols.size() - 1].frameProc = record;
@@ -266,25 +278,10 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else
 				{
-				
-					if (blockIndent != 0 &&
-						//kind != SymbolRecordKind::S_OBJNAME && 
-						//kind != SymbolRecordKind::S_COMPILE3 &&
-						//kind != (SymbolRecordKind)0x1124 && // S_UNAMESPACE
-						kind != (SymbolRecordKind)0x113a && // S_FRAMECOOKIE
-						kind != (SymbolRecordKind)0x1139 && // && // S_CALLSITEINFO 
-						kind != (SymbolRecordKind)0x115E // && // S_HEAPALLOCSITE
-						//kind != SymbolRecordKind::S_BUILDINFO &&
-						//kind != SymbolRecordKind::S_LABEL32
-					)
+					if (blockIndent != 0)
 					{
 						PDB_ASSERT(false, "Unhandled record kind 0x%X\n", record->header.kind);
 					}
-				}
-
-				if (rva == 0x7B3C20)
-				{
-					printf("Debug\n");
 				}
 
 				if (rva == 0u)

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -1,0 +1,386 @@
+// Copyright 2011-2022, Molecular Matters GmbH <office@molecular-matters.com>
+// See LICENSE.txt for licensing details (2-clause BSD License: https://opensource.org/licenses/BSD-2-Clause)
+
+#include "Examples_PCH.h"
+#include "ExampleTimedScope.h"
+#include "PDB_RawFile.h"
+#include "PDB_DBIStream.h"
+#include "PDB_TPIStream.h"
+
+namespace
+{
+	struct FunctionRecords
+	{
+		size_t index;
+		size_t size;
+	};
+
+	struct FunctionRecord
+	{
+		enum class Kind : uint8_t
+		{
+			None = 0,
+			Block = 1,
+			Variable = 2
+		};
+
+		Kind kind;
+
+		union
+		{
+			struct
+			{
+				size_t nameIndex;
+				size_t typeIndex;
+			} variable;
+
+			struct
+			{
+				FunctionRecords records;
+			} block;
+		};
+	};
+
+	struct FunctionSymbol
+	{
+		std::string name;
+		uint32_t rva;
+		uint32_t size;
+		const PDB::CodeView::DBI::Record* frameProc;
+
+		FunctionRecords records;
+	};
+}
+
+using SymbolRecordKind = PDB::CodeView::DBI::SymbolRecordKind;
+
+// Defined in ExampleTypes.cpp
+extern std::string GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeIndex);
+
+void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStream& dbiStream, const PDB::TPIStream& tpiStream);
+void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStream& dbiStream, const PDB::TPIStream& tpiStream)
+{
+	TimedScope total("\nRunning example \"Function variables\"");
+
+	// in order to keep the example easy to understand, we load the PDB data serially.
+	// note that this can be improved a lot by reading streams concurrently.
+
+	// prepare the image section stream first. it is needed for converting section + offset into an RVA
+	TimedScope sectionScope("Reading image section stream");
+	const PDB::ImageSectionStream imageSectionStream = dbiStream.CreateImageSectionStream(rawPdbFile);
+	sectionScope.Done();
+
+
+	// prepare the module info stream for grabbing function symbols from modules
+	TimedScope moduleScope("Reading module info stream");
+	const PDB::ModuleInfoStream moduleInfoStream = dbiStream.CreateModuleInfoStream(rawPdbFile);
+	moduleScope.Done();
+
+
+	// prepare symbol record stream needed by the public stream
+	TimedScope symbolStreamScope("Reading symbol record stream");
+	const PDB::CoalescedMSFStream symbolRecordStream = dbiStream.CreateSymbolRecordStream(rawPdbFile);
+	symbolStreamScope.Done();
+
+
+	// note that we only use unordered_set in order to keep the example code easy to understand.
+	// using other hash set implementations like e.g. abseil's Swiss Tables (https://abseil.io/about/design/swisstables) is *much* faster.
+	std::vector<FunctionSymbol> functionSymbols;
+	std::unordered_set<uint32_t> seenFunctionRVAs;
+
+	// start by reading the module stream, grabbing every function symbol we can find.
+	// in most cases, this gives us ~90% of all function symbols already, along with their size.
+	{
+		TimedScope scope("Storing function symbols from modules");
+
+		const PDB::ArrayView<PDB::ModuleInfoStream::Module> modules = moduleInfoStream.GetModules();
+
+		uint32_t blockIndent = 0;
+
+		for (const PDB::ModuleInfoStream::Module& module : modules)
+		{
+			if (!module.HasSymbolStream())
+			{
+				continue;
+			}
+
+			const PDB::ModuleSymbolStream moduleSymbolStream = module.CreateSymbolStream(rawPdbFile);
+			moduleSymbolStream.ForEachSymbol([&tpiStream, &functionSymbols, &seenFunctionRVAs, &imageSectionStream, &blockIndent](const PDB::CodeView::DBI::Record* record)
+			{
+				const SymbolRecordKind kind = record->header.kind;
+				const PDB::CodeView::DBI::Record::Data& data = record->data;
+
+				// only grab function symbols from the module streams
+				const char* name = nullptr;
+				uint32_t rva = 0u;
+				uint32_t size = 0u;
+
+				if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_END)
+				{
+					PDB_ASSERT(blockIndent > 0, "BlockIndent for S_END is 0");
+					blockIndent--;
+					printf("%*sS_END\n", blockIndent * 4, "");
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_BLOCK32)
+				{
+					const uint32_t offset = imageSectionStream.ConvertSectionOffsetToRVA(data.S_BLOCK32.section, data.S_BLOCK32.offset);
+
+					printf("%*sS_BLOCK32: '%s' | Code Offset 0x%X\n", blockIndent*4, "", data.S_BLOCK32.name, offset);
+					blockIndent++;
+				}
+				else if (kind == SymbolRecordKind::S_LABEL32)
+				{
+					printf("%*sS_LABEL32: '%s' | Offset 0x%X\n", blockIndent * 4, "", data.S_LABEL32.name, data.S_LABEL32.offset);
+				}
+				else if(kind == SymbolRecordKind::S_CONSTANT)
+				{
+					const std::string typeName = GetTypeName(tpiStream, record->data.S_CONSTANT.typeIndex);
+
+					printf("%*sS_CONSTANT: '%s' | Value 0x%X\n", blockIndent*4, "", typeName.c_str(), data.S_CONSTANT.value);
+				}
+				else if(kind == SymbolRecordKind::S_LOCAL)
+				{
+					const std::string typeName = GetTypeName(tpiStream, data.S_LOCAL.typeIndex);
+					printf("%*sS_LOCAL: '%s' -> '%s'\n", blockIndent*4, "", typeName.c_str(), data.S_LOCAL.name);
+				}
+				else if (kind == SymbolRecordKind::S_DEFRANGE_REGISTER)
+				{
+					printf("%*sS_DEFRANGE_REGISTER: Register 0x%X\n", blockIndent * 4, "", record->data.S_DEFRANGE_REGISTER.reg);
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_LDATA32)
+				{
+					if (blockIndent > 0)
+					{
+						const std::string typeName = GetTypeName(tpiStream, record->data.S_CONSTANT.typeIndex);
+						printf("%*sS_LDATA32: '%s' -> '%s'\n", blockIndent * 4, "", record->data.S_LDATA32.name, typeName.c_str());
+					}
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_UDT)
+				{
+					const std::string typeName = GetTypeName(tpiStream, record->data.S_UDT.typeIndex);
+
+					printf("%*sS_UDT: '%s' -> '%s'\n", blockIndent * 4, "", record->data.S_UDT.name, typeName.c_str());
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_REGREL32)
+				{
+					const std::string typeName = GetTypeName(tpiStream, record->data.S_REGREL32.typeIndex);
+
+					//PDB_ASSERT(data.S_REGREL32.reg == PDB::CodeView::DBI::Register::RSP, "Register %i != RSP", (uint16_t)data.S_REGREL32.reg);
+
+					printf("%*sS_REGREL32: '%s' -> '%s' | Register %i | Register Offset 0x%X\n", blockIndent * 4, "", data.S_REGREL32.name, typeName.c_str(), data.S_REGREL32.reg, data.S_REGREL32.offset);
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_FRAMEPROC)
+				{
+					functionSymbols[functionSymbols.size() - 1].frameProc = record;
+					return;
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_THUNK32)
+				{
+					if (record->data.S_THUNK32.thunk == PDB::CodeView::DBI::ThunkOrdinal::TrampolineIncremental)
+					{
+						// we have never seen incremental linking thunks stored inside a S_THUNK32 symbol, but better safe than sorry
+						name = "ILT - Thunk";
+						rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_THUNK32.section, record->data.S_THUNK32.offset);
+						size = 5u;
+					}
+					else
+					{
+						name = record->data.S_THUNK32.name;
+						rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_THUNK32.section, record->data.S_THUNK32.offset);
+						size = data.S_THUNK32.length; // Correct ?
+					}
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_TRAMPOLINE)
+				{
+					// incremental linking thunks are stored in the linker module
+					name = "ILT - Trampoline";
+					rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_TRAMPOLINE.thunkSection, record->data.S_TRAMPOLINE.thunkOffset);
+					size = 5u;
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_LPROC32)
+				{
+					name = record->data.S_LPROC32.name;
+					rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_LPROC32.section, record->data.S_LPROC32.offset);
+					size = record->data.S_LPROC32.codeSize;
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_GPROC32)
+				{
+					name = record->data.S_GPROC32.name;
+					rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_GPROC32.section, record->data.S_GPROC32.offset);
+					size = record->data.S_GPROC32.codeSize;
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_LPROC32_ID)
+				{
+					name = record->data.S_LPROC32_ID.name;
+					rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_LPROC32_ID.section, record->data.S_LPROC32_ID.offset);
+					size = record->data.S_LPROC32_ID.codeSize;
+				}
+				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_GPROC32_ID)
+				{
+					name = record->data.S_GPROC32_ID.name;
+					rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_GPROC32_ID.section, record->data.S_GPROC32_ID.offset);
+					size = record->data.S_GPROC32_ID.codeSize;
+				}
+				else
+				{
+				
+					if (blockIndent != 0 &&
+						//kind != SymbolRecordKind::S_OBJNAME && 
+						//kind != SymbolRecordKind::S_COMPILE3 &&
+						//kind != (SymbolRecordKind)0x1124 && // S_UNAMESPACE
+						kind != (SymbolRecordKind)0x113a && // S_FRAMECOOKIE
+						kind != (SymbolRecordKind)0x1139 && // && // S_CALLSITEINFO 
+						kind != (SymbolRecordKind)0x115E // && // S_HEAPALLOCSITE
+						//kind != SymbolRecordKind::S_BUILDINFO &&
+						//kind != SymbolRecordKind::S_LABEL32
+					)
+					{
+						PDB_ASSERT(false, "Unhandled record kind 0x%X\n", record->header.kind);
+					}
+				}
+
+				if (rva == 0x7B3C20)
+				{
+					printf("Debug\n");
+				}
+
+				if (rva == 0u)
+				{
+					return;
+				}
+
+				PDB_ASSERT(blockIndent == 0, "BlockIndent %u != 0", blockIndent);
+
+				printf("%*sFunction: '%s' | RVA 0x%X\n", blockIndent*4, "", name, rva);
+
+				blockIndent++;
+
+				functionSymbols.push_back(FunctionSymbol{ name, rva, size, nullptr, {0, 0} });
+				seenFunctionRVAs.emplace(rva);
+			});
+		}
+
+		scope.Done(modules.GetLength());
+	}
+
+	// we don't need to touch global symbols in this case.
+	// most of the data we need can be obtained from the module symbol streams, and the global symbol stream only offers data symbols on top of that, which we are not interested in.
+	// however, there can still be public function symbols we haven't seen yet in any of the modules, especially for PDBs that don't provide module-specific information.
+
+	// read public symbols
+	TimedScope publicScope("Reading public symbol stream");
+	const PDB::PublicSymbolStream publicSymbolStream = dbiStream.CreatePublicSymbolStream(rawPdbFile);
+	publicScope.Done();
+	{
+		TimedScope scope("Storing public function symbols");
+
+		const PDB::ArrayView<PDB::HashRecord> hashRecords = publicSymbolStream.GetRecords();
+		const size_t count = hashRecords.GetLength();
+
+		for (const PDB::HashRecord& hashRecord : hashRecords)
+		{
+			const PDB::CodeView::DBI::Record* record = publicSymbolStream.GetRecord(symbolRecordStream, hashRecord);
+			if ((PDB_AS_UNDERLYING(record->data.S_PUB32.flags) & PDB_AS_UNDERLYING(PDB::CodeView::DBI::PublicSymbolFlags::Function)) == 0u)
+			{
+				// ignore everything that is not a function
+				continue;
+			}
+
+			const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_PUB32.section, record->data.S_PUB32.offset);
+			if (rva == 0u)
+			{
+				// certain symbols (e.g. control-flow guard symbols) don't have a valid RVA, ignore those
+				continue;
+			}
+
+			// check whether we already know this symbol from one of the module streams
+			const auto it = seenFunctionRVAs.find(rva);
+			if (it != seenFunctionRVAs.end())
+			{
+				// we know this symbol already, ignore it
+				continue;
+			}
+
+			// this is a new function symbol, so store it.
+			// note that we don't know its size yet.
+			functionSymbols.push_back(FunctionSymbol{ record->data.S_PUB32.name, rva, 0u, nullptr, {0, 0} });
+		}
+
+		scope.Done(count);
+	}
+
+
+	// we still need to find the size of the public function symbols.
+	// this can be deduced by sorting the symbols by their RVA, and then computing the distance between the current and the next symbol.
+	// this works since functions are always mapped to executable pages, so they aren't interleaved by any data symbols.
+	TimedScope sortScope("std::sort function symbols");
+	std::sort(functionSymbols.begin(), functionSymbols.end(), [](const FunctionSymbol& lhs, const FunctionSymbol& rhs)
+	{
+		return lhs.rva < rhs.rva;
+	});
+	sortScope.Done();
+
+	const size_t symbolCount = functionSymbols.size();
+	if (symbolCount != 0u)
+	{
+		TimedScope computeScope("Computing function symbol sizes");
+
+		size_t foundCount = 0u;
+
+		// we have at least 1 symbol.
+		// compute missing symbol sizes by computing the distance from this symbol to the next.
+		// note that this includes "int 3" padding after the end of a function. if you don't want that, but the actual number of bytes of
+		// the function's code, your best bet is to use a disassembler instead.
+		for (size_t i = 0u; i < symbolCount - 1u; ++i)
+		{
+			FunctionSymbol& currentSymbol = functionSymbols[i];
+			if (currentSymbol.size != 0u)
+			{
+				// the symbol's size is already known
+				continue;
+			}
+
+			const FunctionSymbol& nextSymbol = functionSymbols[i + 1u];
+			const size_t size = nextSymbol.rva - currentSymbol.rva;
+			(void)size; // unused
+			++foundCount;
+		}
+
+		// we know have the sizes of all symbols, except the last.
+		// this can be found by going through the contributions, if needed.
+		FunctionSymbol& lastSymbol = functionSymbols[symbolCount - 1u];
+		if (lastSymbol.size != 0u)
+		{
+			// bad luck, we can't deduce the last symbol's size, so have to consult the contributions instead.
+			// we do a linear search in this case to keep the code simple.
+			const PDB::SectionContributionStream sectionContributionStream = dbiStream.CreateSectionContributionStream(rawPdbFile);
+			const PDB::ArrayView<PDB::DBI::SectionContribution> sectionContributions = sectionContributionStream.GetContributions();
+			for (const PDB::DBI::SectionContribution& contribution : sectionContributions)
+			{
+				const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(contribution.section, contribution.offset);
+				if (rva == 0u)
+				{
+					printf("Contribution has invalid RVA\n");
+					continue;
+				}
+
+				if (rva == lastSymbol.rva)
+				{
+					lastSymbol.size = contribution.size;
+					break;
+				}
+				
+				if (rva > lastSymbol.rva)
+				{
+					// should have found the contribution by now
+					printf("Unknown contribution for symbol %s at RVA 0x%X", lastSymbol.name.c_str(), lastSymbol.rva);
+					break;
+				}
+			}
+		}
+
+		computeScope.Done(foundCount);
+	}
+
+	total.Done(functionSymbols.size());
+}

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -136,7 +136,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				{
 					const std::string typeName = GetTypeName(tpiStream, record->data.S_CONSTANT.typeIndex);
 
-					printf("%*sS_CONSTANT: '%s' | Value 0x%X\n", blockIndent*4, "", typeName.c_str(), data.S_CONSTANT.value);
+					printf("%*sS_CONSTANT: '%s' -> '%s' | Value 0x%X\n", blockIndent*4, "", typeName.c_str(), data.S_CONSTANT.name, data.S_CONSTANT.value);
 				}
 				else if(kind == SymbolRecordKind::S_LOCAL)
 				{

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -220,7 +220,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_FRAMEPROC)
 				{
-					Printf(blockLevel, "S_FRAMEPROC: <TODO>\n");
+					Printf(blockLevel, "S_FRAMEPROC: Size %u | Padding %u | Padding Offset 0x%X | Callee Registers Size %u\n", data.S_FRAMEPROC.cbFrame, data.S_FRAMEPROC.cbPad, data.S_FRAMEPROC.offPad, data.S_FRAMEPROC.cbSaveRegs);
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_THUNK32)
 				{

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -61,31 +61,23 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 	const PDB::ImageSectionStream imageSectionStream = dbiStream.CreateImageSectionStream(rawPdbFile);
 	sectionScope.Done();
 
-
 	// prepare the module info stream for grabbing function symbols from modules
 	TimedScope moduleScope("Reading module info stream");
 	const PDB::ModuleInfoStream moduleInfoStream = dbiStream.CreateModuleInfoStream(rawPdbFile);
 	moduleScope.Done();
-
 
 	// prepare symbol record stream needed by the public stream
 	TimedScope symbolStreamScope("Reading symbol record stream");
 	const PDB::CoalescedMSFStream symbolRecordStream = dbiStream.CreateSymbolRecordStream(rawPdbFile);
 	symbolStreamScope.Done();
 
-	// note that we only use unordered_set in order to keep the example code easy to understand.
-	// using other hash set implementations like e.g. abseil's Swiss Tables (https://abseil.io/about/design/swisstables) is *much* faster.
-	std::vector<FunctionSymbol> functionSymbols;
-	std::unordered_set<uint32_t> seenFunctionRVAs;
-
-	// start by reading the module stream, grabbing every function symbol we can find.
-	// in most cases, this gives us ~90% of all function symbols already, along with their size.
 	{
-		TimedScope scope("Storing function symbols from modules");
+		TimedScope scope("Printing function variable records from modules\n");
 
 		const PDB::ArrayView<PDB::ModuleInfoStream::Module> modules = moduleInfoStream.GetModules();
 
 		uint32_t blockLevel = 0;
+		uint32_t recordCount = 0;
 
 		for (const PDB::ModuleInfoStream::Module& module : modules)
 		{
@@ -95,21 +87,21 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 			}
 
 			const PDB::ModuleSymbolStream moduleSymbolStream = module.CreateSymbolStream(rawPdbFile);
-			moduleSymbolStream.ForEachSymbol([&tpiStream, &functionSymbols, &seenFunctionRVAs, &imageSectionStream, &blockLevel](const PDB::CodeView::DBI::Record* record)
+			moduleSymbolStream.ForEachSymbol([&tpiStream, &imageSectionStream, &blockLevel, &recordCount](const PDB::CodeView::DBI::Record* record)
 			{
 				const SymbolRecordKind kind = record->header.kind;
 				const PDB::CodeView::DBI::Record::Data& data = record->data;
 
-				// only grab function symbols from the module streams
-				const char* name = nullptr;
-				uint32_t rva = 0u;
-				uint32_t size = 0u;
-
 				if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_END)
 				{
-					PDB_ASSERT(blockLevel > 0, "BlockIndent for S_END is 0");
+					PDB_ASSERT(blockLevel > 0, "Block level for S_END is 0");
 					blockLevel--;
 					Printf(blockLevel, "S_END\n");
+
+					if (blockLevel == 0)
+					{
+						Printf(0, "\n");
+					}
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_BLOCK32)
 				{
@@ -200,7 +192,6 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 						Printf(blockLevel, "S_LTHREAD32: '%s' -> '%s'\n", data.S_LTHREAD32.name, typeName.c_str());
 					}
 				}
-
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_UDT)
 				{
 					const std::string typeName = GetVariableTypeName(tpiStream, data.S_UDT.typeIndex);
@@ -229,204 +220,74 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_FRAMEPROC)
 				{
-					functionSymbols[functionSymbols.size() - 1].frameProc = record;
-					return;
+					Printf(blockLevel, "S_FRAMEPROC: <TODO>\n");
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_THUNK32)
 				{
+					PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
+
 					if (data.S_THUNK32.thunk == PDB::CodeView::DBI::ThunkOrdinal::TrampolineIncremental)
 					{
 						// we have never seen incremental linking thunks stored inside a S_THUNK32 symbol, but better safe than sorry
-						name = "ILT - Thunk";
-						rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_THUNK32.section, data.S_THUNK32.offset);
-						size = 5u;
+						const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_THUNK32.section, data.S_THUNK32.offset);
+						Printf(blockLevel, "Function: 'ILT/Thunk' | RVA 0x%X\n", rva);;
 					}
 					else
 					{
-						name = data.S_THUNK32.name;
-						rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_THUNK32.section, data.S_THUNK32.offset);
-						size = data.S_THUNK32.length; // Correct ?
+						const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_THUNK32.section, data.S_THUNK32.offset);
+						Printf(blockLevel, "S_THUNK32 Function '%s' | RVA 0x%X\n", data.S_THUNK32.name, rva);
+						blockLevel++;
 					}
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_TRAMPOLINE)
 				{
+					PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
 					// incremental linking thunks are stored in the linker module
-					name = "ILT - Trampoline";
-					rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_TRAMPOLINE.thunkSection, data.S_TRAMPOLINE.thunkOffset);
-					size = 5u;
+					const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_TRAMPOLINE.thunkSection, data.S_TRAMPOLINE.thunkOffset);
+					Printf(blockLevel, "Function 'ILT/Trampoline' | RVA 0x%X\n", rva);
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_LPROC32)
 				{
-					name = data.S_LPROC32.name;
-					rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_LPROC32.section, data.S_LPROC32.offset);
-					size = data.S_LPROC32.codeSize;
+					PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
+					const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_LPROC32.section, data.S_LPROC32.offset);
+					Printf(blockLevel, "S_LPROC32 Function '%s' | RVA 0x%X\n", data.S_LPROC32.name, rva);
+					blockLevel++;
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_GPROC32)
 				{
-					name = data.S_GPROC32.name;
-					rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_GPROC32.section, data.S_GPROC32.offset);
-					size = data.S_GPROC32.codeSize;
+					PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
+					const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_GPROC32.section, data.S_GPROC32.offset);
+					Printf(blockLevel, "S_GPROC32 Function '%s' | RVA 0x%X\n", data.S_GPROC32.name, rva);
+					blockLevel++;
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_LPROC32_ID)
 				{
-					name = data.S_LPROC32_ID.name;
-					rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_LPROC32_ID.section, data.S_LPROC32_ID.offset);
-					size = data.S_LPROC32_ID.codeSize;
+					PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
+					const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_LPROC32_ID.section, data.S_LPROC32_ID.offset);
+					Printf(blockLevel, "S_LPROC32_ID Function '%s' | RVA 0x%X\n", data.S_LPROC32_ID.name, rva);
+					blockLevel++;
 				}
 				else if (record->header.kind == PDB::CodeView::DBI::SymbolRecordKind::S_GPROC32_ID)
 				{
-					name = data.S_GPROC32_ID.name;
-					rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_GPROC32_ID.section, data.S_GPROC32_ID.offset);
-					size = data.S_GPROC32_ID.codeSize;
+					PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
+					const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(data.S_GPROC32_ID.section, data.S_GPROC32_ID.offset);
+					Printf(blockLevel, "S_GPROC32_ID Function '%s' | RVA 0x%X\n", data.S_GPROC32_ID.name, rva);
+					blockLevel++;
 				}
 				else
 				{
-					if (blockLevel != 0)
+					// We only care about records inside functions.
+					if (blockLevel > 0)
 					{
-						PDB_ASSERT(false, "Unhandled record kind 0x%X with block identation %u\n", record->header.kind, blockLevel);
+						PDB_ASSERT(false, "Unhandled record kind 0x%X with block level %u\n", record->header.kind, blockLevel);
 					}
 				}
 
-				if (rva == 0u)
-				{
-					return;
-				}
+				recordCount++;
 
-				PDB_ASSERT(blockLevel == 0, "BlockLevel %u != 0", blockLevel);
-
-				Printf(blockLevel, "Function: '%s' | RVA 0x%X\n", name, rva);
-
-				if (kind != SymbolRecordKind::S_TRAMPOLINE)
-				{
-					blockLevel++;
-				}
-
-				functionSymbols.push_back(FunctionSymbol{ name, rva, size, nullptr });
-				seenFunctionRVAs.emplace(rva);
 			});
 		}
 
-		scope.Done(modules.GetLength());
+		scope.Done(recordCount);
 	}
-
-	// we don't need to touch global symbols in this case.
-	// most of the data we need can be obtained from the module symbol streams, and the global symbol stream only offers data symbols on top of that, which we are not interested in.
-	// however, there can still be public function symbols we haven't seen yet in any of the modules, especially for PDBs that don't provide module-specific information.
-
-	// read public symbols
-	TimedScope publicScope("Reading public symbol stream");
-	const PDB::PublicSymbolStream publicSymbolStream = dbiStream.CreatePublicSymbolStream(rawPdbFile);
-	publicScope.Done();
-	{
-		TimedScope scope("Storing public function symbols");
-
-		const PDB::ArrayView<PDB::HashRecord> hashRecords = publicSymbolStream.GetRecords();
-		const size_t count = hashRecords.GetLength();
-
-		for (const PDB::HashRecord& hashRecord : hashRecords)
-		{
-			const PDB::CodeView::DBI::Record* record = publicSymbolStream.GetRecord(symbolRecordStream, hashRecord);
-			if ((PDB_AS_UNDERLYING(record->data.S_PUB32.flags) & PDB_AS_UNDERLYING(PDB::CodeView::DBI::PublicSymbolFlags::Function)) == 0u)
-			{
-				// ignore everything that is not a function
-				continue;
-			}
-
-			const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(record->data.S_PUB32.section, record->data.S_PUB32.offset);
-			if (rva == 0u)
-			{
-				// certain symbols (e.g. control-flow guard symbols) don't have a valid RVA, ignore those
-				continue;
-			}
-
-			// check whether we already know this symbol from one of the module streams
-			const auto it = seenFunctionRVAs.find(rva);
-			if (it != seenFunctionRVAs.end())
-			{
-				// we know this symbol already, ignore it
-				continue;
-			}
-
-			// this is a new function symbol, so store it.
-			// note that we don't know its size yet.
-			functionSymbols.push_back(FunctionSymbol{ record->data.S_PUB32.name, rva, 0u, nullptr});
-		}
-
-		scope.Done(count);
-	}
-
-
-	// we still need to find the size of the public function symbols.
-	// this can be deduced by sorting the symbols by their RVA, and then computing the distance between the current and the next symbol.
-	// this works since functions are always mapped to executable pages, so they aren't interleaved by any data symbols.
-	TimedScope sortScope("std::sort function symbols");
-	std::sort(functionSymbols.begin(), functionSymbols.end(), [](const FunctionSymbol& lhs, const FunctionSymbol& rhs)
-	{
-		return lhs.rva < rhs.rva;
-	});
-	sortScope.Done();
-
-	const size_t symbolCount = functionSymbols.size();
-	if (symbolCount != 0u)
-	{
-		TimedScope computeScope("Computing function symbol sizes");
-
-		size_t foundCount = 0u;
-
-		// we have at least 1 symbol.
-		// compute missing symbol sizes by computing the distance from this symbol to the next.
-		// note that this includes "int 3" padding after the end of a function. if you don't want that, but the actual number of bytes of
-		// the function's code, your best bet is to use a disassembler instead.
-		for (size_t i = 0u; i < symbolCount - 1u; ++i)
-		{
-			FunctionSymbol& currentSymbol = functionSymbols[i];
-			if (currentSymbol.size != 0u)
-			{
-				// the symbol's size is already known
-				continue;
-			}
-
-			const FunctionSymbol& nextSymbol = functionSymbols[i + 1u];
-			const size_t size = nextSymbol.rva - currentSymbol.rva;
-			(void)size; // unused
-			++foundCount;
-		}
-
-		// we know have the sizes of all symbols, except the last.
-		// this can be found by going through the contributions, if needed.
-		FunctionSymbol& lastSymbol = functionSymbols[symbolCount - 1u];
-		if (lastSymbol.size != 0u)
-		{
-			// bad luck, we can't deduce the last symbol's size, so have to consult the contributions instead.
-			// we do a linear search in this case to keep the code simple.
-			const PDB::SectionContributionStream sectionContributionStream = dbiStream.CreateSectionContributionStream(rawPdbFile);
-			const PDB::ArrayView<PDB::DBI::SectionContribution> sectionContributions = sectionContributionStream.GetContributions();
-			for (const PDB::DBI::SectionContribution& contribution : sectionContributions)
-			{
-				const uint32_t rva = imageSectionStream.ConvertSectionOffsetToRVA(contribution.section, contribution.offset);
-				if (rva == 0u)
-				{
-					printf("Contribution has invalid RVA\n");
-					continue;
-				}
-
-				if (rva == lastSymbol.rva)
-				{
-					lastSymbol.size = contribution.size;
-					break;
-				}
-				
-				if (rva > lastSymbol.rva)
-				{
-					// should have found the contribution by now
-					printf("Unknown contribution for symbol %s at RVA 0x%X", lastSymbol.name.c_str(), lastSymbol.rva);
-					break;
-				}
-			}
-		}
-
-		computeScope.Done(foundCount);
-	}
-
-	total.Done(functionSymbols.size());
 }

--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -80,6 +80,7 @@ namespace
 extern void ExampleSymbols(const PDB::RawFile&, const PDB::DBIStream&);
 extern void ExampleContributions(const PDB::RawFile&, const PDB::DBIStream&);
 extern void ExampleFunctionSymbols(const PDB::RawFile&, const PDB::DBIStream&);
+extern void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStream& dbiStream, const PDB::TPIStream&);
 extern void ExampleLines(const PDB::RawFile& rawPdbFile, const PDB::DBIStream& dbiStream, const PDB::InfoStream& infoStream);
 extern void ExampleTypes(const PDB::TPIStream&);
 
@@ -154,6 +155,7 @@ int main(int argc, char** argv)
 	ExampleContributions(rawPdbFile, dbiStream);
 	ExampleSymbols(rawPdbFile, dbiStream);
 	ExampleFunctionSymbols(rawPdbFile, dbiStream);
+	ExampleFunctionVariables(rawPdbFile, dbiStream, tpiStream);
 	ExampleLines(rawPdbFile, dbiStream, infoStream);
 	ExampleTypes(tpiStream);
 

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -72,6 +72,8 @@ static const char* GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeInd
 		auto type = static_cast<PDB::CodeView::TPI::TypeIndexKind>(typeIndex);
 		switch (type)
 		{
+		case PDB::CodeView::TPI::TypeIndexKind::T_NOTYPE:
+			return "<NO TYPE>";
 		case PDB::CodeView::TPI::TypeIndexKind::T_HRESULT:
 			return "HRESULT";
 		case PDB::CodeView::TPI::TypeIndexKind::T_32PHRESULT:
@@ -84,15 +86,27 @@ static const char* GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeInd
 		case PDB::CodeView::TPI::TypeIndexKind::T_PVOID:
 			return "PVOID";
 
+		case PDB::CodeView::TPI::TypeIndexKind::T_32PBOOL08:
+		case PDB::CodeView::TPI::TypeIndexKind::T_32PBOOL16:
+		case PDB::CodeView::TPI::TypeIndexKind::T_32PBOOL32:
+		case PDB::CodeView::TPI::TypeIndexKind::T_32PBOOL64:
+		case PDB::CodeView::TPI::TypeIndexKind::T_64PBOOL08:
+		case PDB::CodeView::TPI::TypeIndexKind::T_64PBOOL16:
+		case PDB::CodeView::TPI::TypeIndexKind::T_64PBOOL32:
+		case PDB::CodeView::TPI::TypeIndexKind::T_64PBOOL64:
+			return "PBOOL";
+
 		case PDB::CodeView::TPI::TypeIndexKind::T_BOOL08:
 		case PDB::CodeView::TPI::TypeIndexKind::T_BOOL16:
 		case PDB::CodeView::TPI::TypeIndexKind::T_BOOL32:
 			return "BOOL";
+
 		case PDB::CodeView::TPI::TypeIndexKind::T_RCHAR:
 		case PDB::CodeView::TPI::TypeIndexKind::T_CHAR:
 			return "CHAR";
 		case PDB::CodeView::TPI::TypeIndexKind::T_32PRCHAR:
 		case PDB::CodeView::TPI::TypeIndexKind::T_32PCHAR:
+		case PDB::CodeView::TPI::TypeIndexKind::T_64PRCHAR:
 		case PDB::CodeView::TPI::TypeIndexKind::T_64PCHAR:
 		case PDB::CodeView::TPI::TypeIndexKind::T_PRCHAR:
 		case PDB::CodeView::TPI::TypeIndexKind::T_PCHAR:
@@ -171,6 +185,7 @@ static const char* GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeInd
 		case PDB::CodeView::TPI::TypeIndexKind::T_PUINT4:
 			return "PUINT";
 		default:
+			PDB_ASSERT(false, "Unhandled special type %u", typeIndex);
 			break;
 		}
 	}

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -717,8 +717,6 @@ std::string GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeIndex)
 
 	if (typeName == nullptr)
 	{
-		std::string result;
-
 		PDB_ASSERT(referencedType != nullptr, "Neither typeName nor referencedType are set.");
 
 		if (referencedType->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_POINTER)
@@ -759,7 +757,20 @@ std::string GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeIndex)
 				return "resolving method type failed";
 			}
 
-			return methodPrototype;
+			std::string classTypeName = GetTypeName(tpiStream, referencedType->data.LF_MFUNCTION.classtype);
+			classTypeName += "::*";
+
+			const int stringLength = std::snprintf(nullptr, 0, methodPrototype.c_str(), classTypeName.c_str());
+
+			PDB_ASSERT(stringLength > 0, "String length %i <= 0", stringLength);
+
+			std::string result;
+
+			result.resize((uint64_t)stringLength);
+
+			std::snprintf(result.data(), result.size() + 1, methodPrototype.c_str(), classTypeName.c_str());
+
+			return result;
 		}
 		else
 		{

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -119,39 +119,42 @@ namespace PDB
 			// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2735
 			enum class PDB_NO_DISCARD SymbolRecordKind : uint16_t
 			{
-				S_END =				0x0006u,		// block, procedure, "with" or thunk end
-				S_FRAMEPROC =		0x1012u,		// extra frame and proc information
-				S_OBJNAME =			0x1101u,		// full path to the original compiled .obj. can point to remote locations and temporary files, not necessarily the file that was linked into the executable
-				S_THUNK32 =			0x1102u,		// thunk start
-				S_BLOCK32 =			0x1103u,		// block start
-				S_LABEL32 =			0x1105u,		// code label
-				S_LDATA32 =			0x110Cu,		// (static) local data
-				S_GDATA32 =			0x110Du,		// global data
-				S_PUB32 =			0x110Eu,		// public symbol
-				S_LPROC32 =			0x110Fu,		// local procedure start
-				S_GPROC32 =			0x1110u,		// global procedure start
-				S_REGREL32 =		0x1111u,		// register relative address
-				S_LTHREAD32 =		0x1112u,		// (static) thread-local data
-				S_GTHREAD32 =		0x1113u,		// global thread-local data
-				S_PROCREF =			0x1125u,		// reference to function in any compiland
-				S_LPROCREF =		0x1127u,		// local reference to function in any compiland
-				S_TRAMPOLINE =		0x112Cu,		// incremental linking trampoline
-				S_SEPCODE =			0x1132u,		// separated code (from the compiler)
-				S_SECTION =			0x1136u,		// a COFF section in an executable
-				S_COFFGROUP =		0x1137u,		// original COFF group before it was merged into executable sections by the linker, e.g. .CRT$XCU, .rdata, .bss, .lpp_prepatch_hooks
-				S_COMPILE3 =		0x113Cu,		// replacement for S_COMPILE2, more info
-				S_ENVBLOCK =		0x113Du,		// environment block split off from S_COMPILE2
-				S_LPROC32_ID =		0x1146u,		// S_PROC symbol that references ID instead of type
-				S_GPROC32_ID =		0x1147u,		// S_PROC symbol that references ID instead of type
-				S_BUILDINFO =		0x114Cu,		// build info/environment details of a compiland/translation unit
-				S_INLINESITE =		0x114Du,		// inlined function callsite
-				S_INLINESITE_END =	0x114Eu,
-				S_PROC_ID_END =		0x114Fu,
-				S_LPROC32_DPC =		0x1155u,
-				S_LPROC32_DPC_ID =	0x1156u,
-				S_INLINESITE2 =		0x115Du,		// extended inline site information
-				S_UDT =				0x1108u,		// user-defined type
-				S_UDT_ST =			0x1003u,		// user-defined structured types
+				S_END =					0x0006u,		// block, procedure, "with" or thunk end
+				S_FRAMEPROC =			0x1012u,		// extra frame and proc information
+				S_OBJNAME =				0x1101u,		// full path to the original compiled .obj. can point to remote locations and temporary files, not necessarily the file that was linked into the executable
+				S_THUNK32 =				0x1102u,		// thunk start
+				S_BLOCK32 =				0x1103u,		// block start
+				S_LABEL32 =				0x1105u,		// code label
+				S_CONSTANT =        	0x1107u,        // constant symbol
+				S_LDATA32 =				0x110Cu,		// (static) local data
+				S_GDATA32 =				0x110Du,		// global data
+				S_PUB32 =				0x110Eu,		// public symbol
+				S_LPROC32 =				0x110Fu,		// local procedure start
+				S_GPROC32 =				0x1110u,		// global procedure start
+				S_REGREL32 =			0x1111u,		// register relative address
+				S_LTHREAD32 =			0x1112u,		// (static) thread-local data
+				S_GTHREAD32 =			0x1113u,		// global thread-local data
+				S_PROCREF =				0x1125u,		// reference to function in any compiland
+				S_LPROCREF =			0x1127u,		// local reference to function in any compiland
+				S_TRAMPOLINE =			0x112Cu,		// incremental linking trampoline
+				S_SEPCODE =				0x1132u,		// separated code (from the compiler)
+				S_SECTION =				0x1136u,		// a COFF section in an executable
+				S_COFFGROUP =			0x1137u,		// original COFF group before it was merged into executable sections by the linker, e.g. .CRT$XCU, .rdata, .bss, .lpp_prepatch_hooks
+				S_COMPILE3 =			0x113Cu,		// replacement for S_COMPILE2, more info
+				S_ENVBLOCK =			0x113Du,		// environment block split off from S_COMPILE2
+				S_LOCAL =				0x113Eu,		// defines a local symbol in optimized code 
+				S_DEFRANGE_REGISTER =	0x1141u,		// ranges for en-registered symbol
+				S_LPROC32_ID =			0x1146u,		// S_PROC symbol that references ID instead of type
+				S_GPROC32_ID =			0x1147u,		// S_PROC symbol that references ID instead of type
+				S_BUILDINFO =			0x114Cu,		// build info/environment details of a compiland/translation unit
+				S_INLINESITE =			0x114Du,		// inlined function callsite
+				S_INLINESITE_END =		0x114Eu,
+				S_PROC_ID_END =			0x114Fu,
+				S_LPROC32_DPC =			0x1155u,
+				S_LPROC32_DPC_ID =		0x1156u,
+				S_INLINESITE2 =			0x115Du,		// extended inline site information
+				S_UDT =					0x1108u,		// user-defined type
+				S_UDT_ST =				0x1003u,		// user-defined structured types
 			};
 
 			// https://docs.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/thunk-ordinal
@@ -172,8 +175,16 @@ namespace PDB
 				BranchIsland
 			};
 
+			// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvconst.h#L392
 			enum class PDB_NO_DISCARD Register : uint16_t
 			{
+				RAX = 328,
+				RBX = 329,
+				RCX = 330,
+				RDX = 331,
+				RSI = 332,
+				RDI = 333,
+				RBP = 334,
 				RSP = 335
 			};
 
@@ -297,6 +308,24 @@ namespace PDB
 				ARM64X = 0xF9,
 				D3D11_Shader = 0x100
 			};
+
+			// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L3100
+			// represents an address range, used for optimized code debug info
+			struct LocalVariableAddressRange // defines a range of addresses
+			{
+				uint32_t offsetStart;
+				uint16_t isectionStart;
+				uint16_t length;
+			};
+
+			// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L3108
+			// Represents the holes in overall address range, all address is pre-bbt. 
+			// it is for compress and reduce the amount of relocations need.
+			struct LocalVariableAddressGap
+			{
+    			uint16_t offset; // relative offset from the beginning of the live range.
+    			uint16_t length; // length of this gap.
+    		};
 
 			// https://llvm.org/docs/PDB/CodeViewTypes.html#leaf-types
 			struct RecordHeader
@@ -457,6 +486,13 @@ namespace PDB
 
 					struct
 					{
+						uint32_t typeIndex;
+						uint16_t value;
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
+					} S_CONSTANT;
+
+					struct
+					{
 						uint32_t typeIndex;	// refers to a type index in the IPI stream
 					} S_BUILDINFO;
 
@@ -482,9 +518,51 @@ namespace PDB
 						PDB_FLEXIBLE_ARRAY_MEMBER(char, strings);
 					} S_ENVBLOCK;
 
+					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L4190
 					struct
 					{
-						unsigned long typind;
+						uint32_t typeIndex;
+
+						struct 
+						{
+							uint16_t fIsParam : 1; 			// variable is a parameter
+							uint16_t fAddrTaken : 1; 		// address is taken
+							uint16_t fCompGenx : 1; 		// variable is compiler generated
+							uint16_t fIsAggregate : 1;		// the symbol is splitted in temporaries,
+															// which are treated by compiler as 
+															// independent entities
+							uint16_t fIsAggregated : 1;		// Counterpart of fIsAggregate - tells
+															// that it is a part of a fIsAggregate symbol
+							uint16_t fIsAliased : 1;		// variable has multiple simultaneous lifetimes
+							uint16_t fIsAlias : 1; 			// represents one of the multiple simultaneous lifetimes
+							uint16_t fIsRetValue : 1;		// represents a function return value
+							uint16_t fIsOptimizedOut : 1;	// variable has no lifetimes
+							uint16_t fIsEnregGlob : 1; 		// variable is an enregistered global
+							uint16_t fIsEnregStat : 1; 		// variable is an enregistered static
+							uint16_t unused : 5; 			// must be zero
+						} flags;
+
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
+					} S_LOCAL;
+
+					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L4236
+					struct
+					{
+						uint16_t reg; // Register to hold the value of the symbol
+
+						struct
+						{
+							uint16_t maybe : 1;		// May have no user name on one of control flow path.
+							uint16_t padding : 15;	// Padding for future use.
+						} attribute; // Attribute of the register range.
+
+						LocalVariableAddressRange range; // Range of addresses where this program is valid
+						PDB_FLEXIBLE_ARRAY_MEMBER(LocalVariableAddressGap, gaps); // The value is not available in following gaps.
+					} S_DEFRANGE_REGISTER;
+
+					struct
+					{
+						uint32_t typeIndex;
 						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
 					} S_UDT, S_UDT_ST;
 #pragma pack(pop)

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -119,42 +119,50 @@ namespace PDB
 			// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2735
 			enum class PDB_NO_DISCARD SymbolRecordKind : uint16_t
 			{
-				S_END =					0x0006u,		// block, procedure, "with" or thunk end
-				S_FRAMEPROC =			0x1012u,		// extra frame and proc information
-				S_OBJNAME =				0x1101u,		// full path to the original compiled .obj. can point to remote locations and temporary files, not necessarily the file that was linked into the executable
-				S_THUNK32 =				0x1102u,		// thunk start
-				S_BLOCK32 =				0x1103u,		// block start
-				S_LABEL32 =				0x1105u,		// code label
-				S_CONSTANT =        	0x1107u,        // constant symbol
-				S_LDATA32 =				0x110Cu,		// (static) local data
-				S_GDATA32 =				0x110Du,		// global data
-				S_PUB32 =				0x110Eu,		// public symbol
-				S_LPROC32 =				0x110Fu,		// local procedure start
-				S_GPROC32 =				0x1110u,		// global procedure start
-				S_REGREL32 =			0x1111u,		// register relative address
-				S_LTHREAD32 =			0x1112u,		// (static) thread-local data
-				S_GTHREAD32 =			0x1113u,		// global thread-local data
-				S_PROCREF =				0x1125u,		// reference to function in any compiland
-				S_LPROCREF =			0x1127u,		// local reference to function in any compiland
-				S_TRAMPOLINE =			0x112Cu,		// incremental linking trampoline
-				S_SEPCODE =				0x1132u,		// separated code (from the compiler)
-				S_SECTION =				0x1136u,		// a COFF section in an executable
-				S_COFFGROUP =			0x1137u,		// original COFF group before it was merged into executable sections by the linker, e.g. .CRT$XCU, .rdata, .bss, .lpp_prepatch_hooks
-				S_COMPILE3 =			0x113Cu,		// replacement for S_COMPILE2, more info
-				S_ENVBLOCK =			0x113Du,		// environment block split off from S_COMPILE2
-				S_LOCAL =				0x113Eu,		// defines a local symbol in optimized code 
-				S_DEFRANGE_REGISTER =	0x1141u,		// ranges for en-registered symbol
-				S_LPROC32_ID =			0x1146u,		// S_PROC symbol that references ID instead of type
-				S_GPROC32_ID =			0x1147u,		// S_PROC symbol that references ID instead of type
-				S_BUILDINFO =			0x114Cu,		// build info/environment details of a compiland/translation unit
-				S_INLINESITE =			0x114Du,		// inlined function callsite
-				S_INLINESITE_END =		0x114Eu,
-				S_PROC_ID_END =			0x114Fu,
-				S_LPROC32_DPC =			0x1155u,
-				S_LPROC32_DPC_ID =		0x1156u,
-				S_INLINESITE2 =			0x115Du,		// extended inline site information
-				S_UDT =					0x1108u,		// user-defined type
-				S_UDT_ST =				0x1003u,		// user-defined structured types
+				S_END =										0x0006u,		// block, procedure, "with" or thunk end
+				S_FRAMEPROC =								0x1012u,		// extra frame and proc information
+				S_OBJNAME =									0x1101u,		// full path to the original compiled .obj. can point to remote locations and temporary files, not necessarily the file that was linked into the executable
+				S_THUNK32 =									0x1102u,		// thunk start
+				S_BLOCK32 =									0x1103u,		// block start
+				S_LABEL32 =									0x1105u,		// code label
+				S_CONSTANT =        						0x1107u,        // constant symbol
+				S_LDATA32 =									0x110Cu,		// (static) local data
+				S_GDATA32 =									0x110Du,		// global data
+				S_PUB32 =									0x110Eu,		// public symbol
+				S_LPROC32 =									0x110Fu,		// local procedure start
+				S_GPROC32 =									0x1110u,		// global procedure start
+				S_REGREL32 =								0x1111u,		// register relative address
+				S_LTHREAD32 =								0x1112u,		// (static) thread-local data
+				S_GTHREAD32 =								0x1113u,		// global thread-local data
+				S_PROCREF =									0x1125u,		// reference to function in any compiland
+				S_LPROCREF =								0x1127u,		// local reference to function in any compiland
+				S_TRAMPOLINE =								0x112Cu,		// incremental linking trampoline
+				S_SEPCODE =									0x1132u,		// separated code (from the compiler)
+				S_SECTION =									0x1136u,		// a COFF section in an executable
+				S_COFFGROUP =								0x1137u,		// original COFF group before it was merged into executable sections by the linker, e.g. .CRT$XCU, .rdata, .bss, .lpp_prepatch_hooks
+				S_COMPILE3 =								0x113Cu,		// replacement for S_COMPILE2, more info
+				S_ENVBLOCK =								0x113Du,		// environment block split off from S_COMPILE2
+				S_LOCAL =									0x113Eu,		// defines a local symbol in optimized code 
+				S_DEFRANGE_REGISTER =						0x1141u,		// ranges for en-registered symbol
+				S_DEFRANGE_FRAMEPOINTER_REL =				0x1142u,		// range for stack symbol.
+				S_DEFRANGE_SUBFIELD_REGISTER =				0x1143u,		// ranges for en-registered field of symbol
+				S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE =	0x1144u, 		// range for stack symbol span valid full scope of function body, gap might apply.
+				S_DEFRANGE_REGISTER_REL = 					0x1145u, 		// range for symbol address as register + offset.
+				S_LPROC32_ID =								0x1146u,		// S_PROC symbol that references ID instead of type
+				S_GPROC32_ID =								0x1147u,		// S_PROC symbol that references ID instead of type
+				S_BUILDINFO =								0x114Cu,		// build info/environment details of a compiland/translation unit
+				S_INLINESITE =								0x114Du,		// inlined function callsite
+				S_INLINESITE_END =							0x114Eu,
+				S_PROC_ID_END =								0x114Fu,
+				S_FILESTATIC =								0x1153u,
+				S_LPROC32_DPC =								0x1155u,
+				S_LPROC32_DPC_ID =							0x1156u,
+				S_CALLEES =									0x115Au,
+				S_CALLERS =									0x115Bu,
+				S_INLINESITE2 =								0x115Du,		// extended inline site information
+				S_INLINEES =            					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
+				S_UDT =										0x1108u,		// user-defined type
+				S_UDT_ST =									0x1003u,		// user-defined structured types
 			};
 
 			// https://docs.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/thunk-ordinal
@@ -498,6 +506,42 @@ namespace PDB
 
 					struct
 					{
+						uint32_t parent; // pointer to the inliner
+						uint32_t end; // pointer to this block's end
+						uint32_t inlinee; // CV_ItemId of inlinee
+						PDB_FLEXIBLE_ARRAY_MEMBER(uint8_t, binaryAnnotations);
+					} S_INLINESITE;
+
+					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L4199
+					struct
+					{
+						uint32_t typeIndex; // type index
+						uint32_t moduleFilenameOffset; // index of mod filename in stringtable
+
+						struct 
+						{
+							uint16_t fIsParam : 1; 			// variable is a parameter
+							uint16_t fAddrTaken : 1; 		// address is taken
+							uint16_t fCompGenx : 1; 		// variable is compiler generated
+							uint16_t fIsAggregate : 1;		// the symbol is splitted in temporaries,
+															// which are treated by compiler as 
+															// independent entities
+							uint16_t fIsAggregated : 1;		// Counterpart of fIsAggregate - tells
+															// that it is a part of a fIsAggregate symbol
+							uint16_t fIsAliased : 1;		// variable has multiple simultaneous lifetimes
+							uint16_t fIsAlias : 1; 			// represents one of the multiple simultaneous lifetimes
+							uint16_t fIsRetValue : 1;		// represents a function return value
+							uint16_t fIsOptimizedOut : 1;	// variable has no lifetimes
+							uint16_t fIsEnregGlob : 1; 		// variable is an enregistered global
+							uint16_t fIsEnregStat : 1; 		// variable is an enregistered static
+							uint16_t unused : 5; 			// must be zero
+						} flags;
+
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
+					} S_FILESTATIC;
+
+					struct
+					{
 						CompileSymbolFlags flags;
 						CPUType machine;
 						uint16_t versionFrontendMajor;
@@ -559,6 +603,43 @@ namespace PDB
 						LocalVariableAddressRange range; // Range of addresses where this program is valid
 						PDB_FLEXIBLE_ARRAY_MEMBER(LocalVariableAddressGap, gaps); // The value is not available in following gaps.
 					} S_DEFRANGE_REGISTER;
+
+					struct
+					{
+						uint32_t offsetFramePointer;
+						LocalVariableAddressRange range; // Range of addresses where this program is valid
+						PDB_FLEXIBLE_ARRAY_MEMBER(LocalVariableAddressGap, gaps); // The value is not available in following gaps.
+					} S_DEFRANGE_FRAMEPOINTER_REL;
+
+					struct
+					{
+						uint16_t reg; // Register to hold the value of the symbol
+
+						struct
+						{
+							uint16_t maybe : 1;		// May have no user name on one of control flow path.
+							uint16_t padding : 15;	// Padding for future use.
+						} attribute; // Attribute of the register range.
+
+						uint32_t offsetParent : 12; // Offset in parent variable.
+						uint32_t padding : 20; // Padding for future use.
+						LocalVariableAddressRange range; // Range of addresses where this program is valid
+						PDB_FLEXIBLE_ARRAY_MEMBER(LocalVariableAddressGap, gaps); // The value is not available in following gaps.
+					} S_DEFRANGE_SUBFIELD_REGISTER;
+
+					struct
+					{
+						uint32_t offsetFramePointer;  // offset to frame pointer
+					} S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE;
+
+					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L4382
+					struct
+					{
+						uint32_t count; // Number of functions
+						PDB_FLEXIBLE_ARRAY_MEMBER(uint32_t, funcs); // List of functions, dim == count
+						// uint32_t   invocations[CV_ZEROLEN]; Followed by a parallel array of
+    					// invocation counts. Counts > reclen are assumed to be zero
+					} S_CALLERS, S_CALLEES, S_INLINEES;
 
 					struct
 					{

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -464,7 +464,7 @@ namespace PDB
 						uint32_t offset; 		// Frame relative offset
 						uint16_t reg;			// Register index
 						CookieType cookietype;	// Type of the cookie
-						uint8_t    flags;		// Flags describing this cookie
+						uint8_t flags;			// Flags describing this cookie
 					} S_FRAMECOOKIE;
 
 					struct

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -397,7 +397,7 @@ namespace PDB
 							uint32_t fGuardCFW : 1;					// function contains CFW checks and/or instrumentation
 							uint32_t pad : 9;						// must be zero
 						} flags;
-					}S_FRAMEPROC;
+					} S_FRAMEPROC;
 
 					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L3696
 					struct

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -663,6 +663,18 @@ namespace PDB
 						uint32_t offsetFramePointer;  // offset to frame pointer
 					} S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE;
 
+					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L4279
+					struct
+					{
+						uint16_t  baseRegister; // Register to hold the base pointer of the symbol
+						uint16_t  spilledUDTMember : 1; // Spilled member for s.i.
+						uint16_t  padding : 3; // Padding for future use.
+						uint16_t  offsetParent : 12; // Offset in parent variable.
+						uint32_t  offsetBasePointer; // offset to register
+						LocalVariableAddressRange range;   // Range of addresses where this program is valid
+						PDB_FLEXIBLE_ARRAY_MEMBER(LocalVariableAddressGap, gaps); // The value is not available in following gaps.
+					} S_DEFRANGE_REGISTER_REL;
+
 					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L4500
 					struct 
 					{

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -150,8 +150,8 @@ namespace PDB
 				S_LPROC32_DPC =		0x1155u,
 				S_LPROC32_DPC_ID =	0x1156u,
 				S_INLINESITE2 =		0x115Du,		// extended inline site information
-				S_UDT =			0x1108u,		// user-defined type
-				S_UDT_ST =		0x1003u,		// user-defined structured types
+				S_UDT =				0x1108u,		// user-defined type
+				S_UDT_ST =			0x1003u,		// user-defined structured types
 			};
 
 			// https://docs.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/thunk-ordinal

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -130,7 +130,7 @@ namespace PDB
 				S_PUB32 =			0x110Eu,		// public symbol
 				S_LPROC32 =			0x110Fu,		// local procedure start
 				S_GPROC32 =			0x1110u,		// global procedure start
-				S_REGREL32 =                    0x1111u,                // register relative address
+				S_REGREL32 =		0x1111u,		// register relative address
 				S_LTHREAD32 =		0x1112u,		// (static) thread-local data
 				S_GTHREAD32 =		0x1113u,		// global thread-local data
 				S_PROCREF =			0x1125u,		// reference to function in any compiland


### PR DESCRIPTION
* Added an example of how to print function variables and added the necessary DBI records.
* Some improvements and extensions ExampleTypes, which the function variables example utilized.

Tested with various clang and Unreal Engine 5 PDBs, up to 1.45 GiB in size.

928 MiB clang 13 debug PDB built with VS 2022 along with output from function variables example can be downloaded from here:
http://lukekasz.com/raw_pdb/raw-pdb-function-variables.zip (223 MiB)

**Snippet of example output from clang main function**

```
S_GPROC32 Function 'main' | RVA 0x4D440
    S_FRAMEPROC: Size 7704 | Padding 0 | Padding Offset 0x0 | Callee Registers Size 16
    S_FRAMECOOKIE: Offset 0x1E08 | Register 335 | Type 1
    S_REGREL32: 'Argc' -> 'INT' | Register 335 | Register Offset 0x1E30
    S_REGREL32: 'Argv' -> 'CHAR' | Register 335 | Register Offset 0x1E38
    S_REGREL32: 'X' -> 'llvm::InitLLVM' | Register 335 | Register Offset 0x38
    S_REGREL32: 'C' -> 'std::unique_ptr<clang::driver::Compilation,std::default_delete<clang::driver::Compilation> >' | Register 335 | Register Offset 0x1838
    S_REGREL32: 'Saver' -> 'llvm::StringSaver' | Register 335 | Register Offset 0x9A8
    S_REGREL32: 'Res' -> 'INT' | Register 335 | Register Offset 0x1844
    S_REGREL32: 'MarkEOLs' -> 'BOOL' | Register 335 | Register Offset 0x9E0
    S_REGREL32: 'CanonicalPrefixes' -> 'BOOL' | Register 335 | Register Offset 0xA00
    S_REGREL32: 'DiagClient' -> 'clang::TextDiagnosticPrinter' | Register 335 | Register Offset 0xC38
    S_REGREL32: 'Diags' -> 'clang::DiagnosticsEngine' | Register 335 | Register Offset 0xC68
    S_REGREL32: 'A' -> 'llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator,4096,4096,128>' | Register 335 | Register Offset 0x928
    S_CONSTANT: 'main::__l2::<unnamed-type-RSPQuoting>' -> 'Windows' | Value 0x2
    S_CONSTANT: 'main::__l2::<unnamed-type-RSPQuoting>' -> 'Default' | Value 0x0
    S_REGREL32: 'Args' -> 'llvm::SmallVector<char const *,256>' | Register 335 | Register Offset 0xF8
    S_REGREL32: 'DiagID' -> 'llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs>' | Register 335 | Register Offset 0xC48
    S_REGREL32: 'IsCrash' -> 'BOOL' | Register 335 | Register Offset 0x1848
    S_REGREL32: 'Tokenizer' -> 'void (*)(llvm::StringRef, llvm::StringSaver*, llvm::SmallVectorImpl<char const *>*, BOOL)*' | Register 335 | Register Offset 0x9E8
    S_REGREL32: 'Path' -> 'std::basic_string<char,std::char_traits<char>,std::allocator<char> >' | Register 335 | Register Offset 0xBC8
    S_REGREL32: 'ClangCLMode' -> 'BOOL' | Register 335 | Register Offset 0x9B4
    S_REGREL32: 'TheDriver' -> 'clang::driver::Driver' | Register 335 | Register Offset 0x1268
    S_CONSTANT: 'main::__l2::<unnamed-type-RSPQuoting>' -> 'POSIX' | Value 0x1
    S_UDT: 'main::__l2::<lambda_f6c7c0992c8dcff83428dd17344f0faa>' -> 'main::__l2::<lambda_f6c7c0992c8dcff83428dd17344f0faa>'
    S_REGREL32: 'UseNewCC1Process' -> 'BOOL' | Register 335 | Register Offset 0xC04
    S_REGREL32: 'DiagOpts' -> 'llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions>' | Register 335 | Register Offset 0xC28
    S_REGREL32: 'TargetAndMode' -> 'clang::driver::ParsedClangName' | Register 335 | Register Offset 0x17C0
    S_REGREL32: 'RSPQuoting' -> 'main::__l2::<unnamed-type-RSPQuoting>' | Register 335 | Register Offset 0x9B8
    S_REGREL32: 'FirstArg' -> 'CHAR' | Register 335 | Register Offset 0x9F0
    S_REGREL32: 'SavedStrings' -> 'std::set<std::basic_string<char,std::char_traits<char>,std::allocator<char> >,std::less<std::basic_string<char,std::char_traits<char>,std::allocator<char> > >,std::allocator<std::basic_string<char,std::char_traits<char>,std::allocator<char> > > >' | Register 335 | Register Offset 0xB98
    S_BLOCK32: '' | Code Offset 0x4D62D
        S_REGREL32: '<range>$L0' -> 'llvm::SmallVector<char const *,256>' | Register 335 | Register Offset 0x9C0
        S_REGREL32: '<begin>$L0' -> 'CHAR' | Register 335 | Register Offset 0x9C8
        S_REGREL32: '<end>$L0' -> 'CHAR' | Register 335 | Register Offset 0x9D0
        S_BLOCK32: '' | Code Offset 0x4D693
            S_REGREL32: 'F' -> 'CHAR' | Register 335 | Register Offset 0x9D8
        S_END
    S_END
    ...
```

```cpp
int main(int Argc, const char **Argv) {
  noteBottomOfStack();
  llvm::InitLLVM X(Argc, Argv);
  llvm::setBugReportMsg("PLEASE submit a bug report to " BUG_REPORT_URL
                        " and include the crash backtrace, preprocessed "
                        "source, and associated run script.\n");
  SmallVector<const char *, 256> Args(Argv, Argv + Argc);

  if (llvm::sys::Process::FixupStandardFileDescriptors())
    return 1;

  llvm::InitializeAllTargets();

  llvm::BumpPtrAllocator A;
  llvm::StringSaver Saver(A);

  // Parse response files using the GNU syntax, unless we're in CL mode. There
  // are two ways to put clang in CL compatibility mode: Args[0] is either
  // clang-cl or cl, or --driver-mode=cl is on the command line. The normal
  // command line parsing can't happen until after response file parsing, so we
  // have to manually search for a --driver-mode=cl argument the hard way.
  // Finally, our -cc1 tools don't care which tokenization mode we use because
  // response files written by clang will tokenize the same way in either mode.
  bool ClangCLMode =
      IsClangCL(getDriverMode(Args[0], llvm::makeArrayRef(Args).slice(1)));
  enum { Default, POSIX, Windows } RSPQuoting = Default;
  for (const char *F : Args) {
    if (strcmp(F, "--rsp-quoting=posix") == 0)
      RSPQuoting = POSIX;
    else if (strcmp(F, "--rsp-quoting=windows") == 0)
      RSPQuoting = Windows;
  }
...
```