### PR TITLE
Don't build examples by default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,4 +78,8 @@ target_precompile_headers(raw_pdb
     PDB_PCH.h
 )
 
-add_subdirectory(Examples)
+option(RAWPDB_BUILD_EXAMPLES "Build Examples" OFF)
+
+if(RAWPDB_BUILD_EXAMPLES)
+	add_subdirectory(Examples)
+endif()


### PR DESCRIPTION
This disables example building by default and instead adds an option to enable it.

This is useful because sometimes examples don't build in certain configurations, but the library does.