### PR TITLE
Fixed snprintf into const char*

### DIFF
--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -830,7 +830,7 @@ std::string GetTypeName(const PDB::TPIStream& tpiStream, uint32_t typeIndex)
 
 			result.resize((uint64_t)stringLength);
 
-			std::snprintf(result.data(), result.size() + 1, methodPrototype.c_str(), classTypeName.c_str());
+			std::snprintf(const_cast<char*>(result.data()), result.size() + 1, methodPrototype.c_str(), classTypeName.c_str());
 
 			return result;
 		}


### PR DESCRIPTION
I've tried compiling the examples with MSVC2022, and it didn't work due to this write to `string::data()`. I'm not sure if this works elsewhere, but according to the standard, `data()` returns a `const char*`. With a `const_cast` this is still very much undefined behavior, but at least it compiles now, and it seems to work fine.