### PR TITLE
Arglist LF_MFUNCTION fix and S_REGREL32_INDIR (0x1171)

### DIFF
--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -297,6 +297,15 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 					Printf(blockLevel, "S_GPROC32_ID Function '%s' | RVA 0x%X\n", data.S_GPROC32_ID.name, rva);
 					blockLevel++;
 				}
+				else if (kind == SymbolRecordKind::S_REGREL32_INDIR)
+				{
+					const std::string typeName = GetVariableTypeName(typeTable, data.S_REGREL32_INDIR.typeIndex);
+
+					Printf(blockLevel, "S_REGREL32_INDIR: '%s' -> '%s' | Register %i | Unknown1 0x%X | Unknown2 0x%X\n",
+						data.S_REGREL32_INDIR.name, typeName.c_str(),
+						data.S_REGREL32_INDIR.unknown1,
+						data.S_REGREL32_INDIR.unknown1);
+				}
 				else
 				{
 					// We only care about records inside functions.

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -166,6 +166,7 @@ namespace PDB
 				S_INLINEES =            					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types
+				S_REGREL32_INDIR =                          0x1171u,
 			};
 
 			// https://docs.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/thunk-ordinal
@@ -698,6 +699,16 @@ namespace PDB
 						uint32_t typeIndex;
 						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
 					} S_UDT, S_UDT_ST;
+
+					struct
+					{
+						uint32_t unknown1;
+						uint32_t typeIndex;
+						uint32_t unknown2;
+						Register reg;
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
+
+					} S_REGREL32_INDIR;
 #pragma pack(pop)
 				} data;
 			};

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -163,7 +163,7 @@ namespace PDB
 				S_CALLERS =									0x115Bu,
 				S_INLINESITE2 =								0x115Du,		// extended inline site information
 				S_HEAPALLOCSITE = 							0x115Eu,		// heap allocation site
-				S_INLINEES =            					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
+				S_INLINEES =			 					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
 				S_REGREL32_INDIR =							0x1171u,
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -164,9 +164,9 @@ namespace PDB
 				S_INLINESITE2 =								0x115Du,		// extended inline site information
 				S_HEAPALLOCSITE = 							0x115Eu,		// heap allocation site
 				S_INLINEES =            					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
+				S_REGREL32_INDIR =							0x1171u,
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types
-				S_REGREL32_INDIR =                          0x1171u,
 			};
 
 			// https://docs.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/thunk-ordinal


### PR DESCRIPTION
Fix issue with LF_MFUNCTION not being handled correctly in LF_PROCEDURE and LF_MFUNCTION arglist. This happens when a function or class method has a class method pointer as a parameter.

Fixes https://github.com/MolecularMatters/raw_pdb/issues/60

Also added S_REGREL32_INDIR (0x1171) record kind, which I encountered while testing on the 3.65 GB Qt6WebEngineCored.pdb

Both Qt6WebEngineCore.pdb and Qt6WebEngineCored.pdb used for testing can be downloaded from here: 

http://lukekasz.com/raw_pdb/Qt6WebEngineCore-pdbs.zip