### PR TITLE
Add support for record kind S_REGREL32_ENCTMP (0x1179)

### DIFF
--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -297,6 +297,15 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 					Printf(blockLevel, "S_GPROC32_ID Function '%s' | RVA 0x%X\n", data.S_GPROC32_ID.name, rva);
 					blockLevel++;
 				}
+				else if (kind == SymbolRecordKind::S_REGREL32_INDIR)
+				{
+					const std::string typeName = GetVariableTypeName(typeTable, data.S_REGREL32_INDIR.typeIndex);
+
+					Printf(blockLevel, "S_REGREL32_INDIR: '%s' -> '%s' | Register %i | Unknown1 0x%X | Unknown2 0x%X\n",
+						data.S_REGREL32_INDIR.name, typeName.c_str(),
+						data.S_REGREL32_INDIR.unknown1,
+						data.S_REGREL32_INDIR.unknown1);
+				}
 				else
 				{
 					// We only care about records inside functions.

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -306,6 +306,15 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 						data.S_REGREL32_INDIR.unknown1,
 						data.S_REGREL32_INDIR.unknown1);
 				}
+				else if (kind == SymbolRecordKind::S_REGREL32_ENCTMP)
+				{
+					const std::string typeName = GetVariableTypeName(typeTable, data.S_REGREL32.typeIndex);
+
+					Printf(blockLevel, "S_REGREL32_ENCTMP: '%s' -> '%s' | Register %i | Register Offset 0x%X\n",
+						data.S_REGREL32.name, typeName.c_str(),
+						data.S_REGREL32.reg,
+						data.S_REGREL32.offset);
+						}
 				else
 				{
 					// We only care about records inside functions.

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -166,6 +166,7 @@ namespace PDB
 				S_INLINEES =            					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types
+				S_REGREL32_INDIR =                          0x1171u,
 			};
 
 			// https://docs.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/thunk-ordinal
@@ -698,6 +699,16 @@ namespace PDB
 						uint32_t typeIndex;
 						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
 					} S_UDT, S_UDT_ST;
+
+					struct
+					{
+						uint32_t unknown1;
+						uint32_t typeIndex;
+						uint32_t unknown2;
+						Register reg;
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
+
+					} S_REGREL32_INDIR;
 #pragma pack(pop)
 				} data;
 			};

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -165,6 +165,7 @@ namespace PDB
 				S_HEAPALLOCSITE = 							0x115Eu,		// heap allocation site
 				S_INLINEES =			 					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
 				S_REGREL32_INDIR =							0x1171u,
+				S_REGREL32_ENCTMP =                         0x1179u,
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types
 			};
@@ -501,7 +502,7 @@ namespace PDB
 						uint32_t typeIndex;
 						Register reg;
 						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
-					} S_REGREL32;
+					} S_REGREL32, S_REGREL32_ENCTMP;
 
 					struct
 					{

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -163,7 +163,7 @@ namespace PDB
 				S_CALLERS =									0x115Bu,
 				S_INLINESITE2 =								0x115Du,		// extended inline site information
 				S_HEAPALLOCSITE = 							0x115Eu,		// heap allocation site
-				S_INLINEES =            					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
+				S_INLINEES =			 					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
 				S_REGREL32_INDIR =							0x1171u,
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -164,9 +164,9 @@ namespace PDB
 				S_INLINESITE2 =								0x115Du,		// extended inline site information
 				S_HEAPALLOCSITE = 							0x115Eu,		// heap allocation site
 				S_INLINEES =            					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
+				S_REGREL32_INDIR =							0x1171u,
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types
-				S_REGREL32_INDIR =                          0x1171u,
 			};
 
 			// https://docs.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/thunk-ordinal


### PR DESCRIPTION
Should be merged after https://github.com/MolecularMatters/raw_pdb/pull/62, as the changes in that PR have also been merged into this branch, to avoid a conflict.

Source code compiled with VS 2022

```
namespace
{
	class base
	{
	};

	class derived1 : virtual public base
	{		
	};
}

int main()
{
	derived1 temp;
	return 0;
}
```

ExamplesFunctionVariables output:

```
S_LPROC32 Function '`anonymous namespace'::derived1::derived1' | RVA 0x11780
    S_FRAMEPROC: Size 200 | Padding 192 | Padding Offset 0x0 | Callee Registers Size 16
    S_REGREL32: 'this' -> '`anonymous-namespace'::derived1' | Register 334 | Register Offset 0xE0
    S_REGREL32_ENCTMP: '$initVBases' -> 'UINT' | Register 334 | Register Offset 0xE8
S_END
```


Fixes https://github.com/MolecularMatters/raw_pdb/issues/58

Test PDB: http://lukekasz.com/raw_pdb/record-kind-1179.pdb