### PR TITLE
Chrome dll pdb fixes

### DIFF
--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -121,7 +121,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				else if(kind == SymbolRecordKind::S_LOCAL)
 				{
 					const std::string typeName = GetVariableTypeName(typeTable, data.S_LOCAL.typeIndex);
-					Printf(blockLevel, "S_LOCAL: '%s' -> '%s'\n", typeName.c_str(), data.S_LOCAL.name);
+					Printf(blockLevel, "S_LOCAL: '%s' -> '%s' | Param: %s | Optimized Out: %s\n", typeName.c_str(), data.S_LOCAL.name, data.S_LOCAL.flags.fIsParam ? "True" : "False", data.S_LOCAL.flags.fIsOptimizedOut ? "True" : "False");
 				}
 				else if (kind == SymbolRecordKind::S_DEFRANGE_REGISTER)
 				{

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -27,7 +27,7 @@ static std::string GetVariableTypeName(const TypeTable& typeTable, uint32_t type
 	return typeName;
 }
 
-void Printf(uint32_t indent, const char* format, ...) 
+static void Printf(uint32_t indent, const char* format, ...) 
 {
 	va_list args;
 	va_start(args, format);

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -97,6 +97,10 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 						Printf(0, "\n");
 					}
 				}
+				else if(kind == SymbolRecordKind::S_SKIP)
+				{
+					Printf(blockLevel, "S_SKIP\n");
+				}
 				else if (kind == SymbolRecordKind::S_BLOCK32)
 				{
 					const uint32_t offset = imageSectionStream.ConvertSectionOffsetToRVA(data.S_BLOCK32.section, data.S_BLOCK32.offset);

--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -161,7 +161,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if (kind == SymbolRecordKind::S_INLINESITE)
 				{
-					Printf(blockLevel, "S_INLINESITE: Parent 0x % X\n", data.S_INLINESITE.parent);
+					Printf(blockLevel, "S_INLINESITE: Parent 0x%X\n", data.S_INLINESITE.parent);
 					blockLevel++;
 				}
 				else if (kind == SymbolRecordKind::S_INLINESITE_END)

--- a/src/Examples/ExampleLines.cpp
+++ b/src/Examples/ExampleLines.cpp
@@ -92,6 +92,11 @@ void ExampleLines(const PDB::RawFile& rawPdbFile, const PDB::DBIStream& dbiStrea
 					moduleLineStream.ForEachLinesBlock(lineSection, 
 					[&lineSection, &sections, &filenames, &lines](const PDB::CodeView::DBI::LinesFileBlockHeader* linesBlockHeader, const PDB::CodeView::DBI::Line* blocklines, const PDB::CodeView::DBI::Column* blockColumns)
 					{
+						if (linesBlockHeader->numLines == 0)
+						{
+							return;
+						}
+
 						const PDB::CodeView::DBI::Line& firstLine = blocklines[0];
 
 						const uint16_t sectionIndex  = lineSection->linesHeader.sectionIndex;

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -18,6 +18,16 @@ PDB_DISABLE_WARNING_CLANG("-Wformat-nonliteral")
 
 std::string GetTypeName(const TypeTable& typeTable, uint32_t typeIndex);
 
+static void Printf(const char* format, ...) 
+{
+	va_list args;
+	va_start(args, format);
+
+	vprintf(format, args);
+
+	va_end(args);
+}
+
 static uint8_t GetLeafSize(PDB::CodeView::TPI::TypeRecordKind kind)
 {
 	if (kind < PDB::CodeView::TPI::TypeRecordKind::LF_NUMERIC)
@@ -45,7 +55,7 @@ static uint8_t GetLeafSize(PDB::CodeView::TPI::TypeRecordKind kind)
 		return sizeof(PDB::CodeView::TPI::TypeRecordKind) + sizeof(uint64_t);
 
 	default:
-		printf("Error! 0x%04x bogus type encountered, aborting...\n", PDB_AS_UNDERLYING(kind));
+		Printf("Error! 0x%04x bogus type encountered, aborting...\n", PDB_AS_UNDERLYING(kind));
 	}
 	return 0;
 }
@@ -651,44 +661,44 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 						if (underlyingType->header.kind != PDB::CodeView::TPI::TypeRecordKind::LF_PROCEDURE)
 						{
 							if (modifierRecord)
-								printf("[0x%X]%s %s", offset, GetModifierName(modifierRecord), typeName);
+								Printf("[0x%X]%s %s", offset, GetModifierName(modifierRecord), typeName);
 							else
-								printf("[0x%X]%s", offset, typeName);
+								Printf("[0x%X]%s", offset, typeName);
 
 							for (size_t j = 0; j < pointerLevel; j++)
-								printf("*");
+								Printf("*");
 
-							printf(" %s\n", leafName);
+							Printf(" %s\n", leafName);
 						}
 						else
 						{
 							if (!GetFunctionPrototype(typeTable, underlyingType, functionPrototype))
 								break;
 
-							printf("[0x%X]", offset);
-							printf(functionPrototype.c_str(), leafName);
-							printf("\n");
+							Printf("[0x%X]", offset);
+							Printf(functionPrototype.c_str(), leafName);
+							Printf("\n");
 						}
 					}
 					else
 					{
-						printf("[0x%X]%s", offset, typeName);
+						Printf("[0x%X]%s", offset, typeName);
 
 						for (size_t j = 0; j < pointerLevel; j++)
-							printf("*");
+							Printf("*");
 
 						if (referencedType->data.LF_POINTER.attr.isvolatile)
-							printf(" volatile");
+							Printf(" volatile");
 						else if (referencedType->data.LF_POINTER.attr.isconst)
-							printf(" const");
+							Printf(" const");
 
-						printf(" %s\n", leafName);
+						Printf(" %s\n", leafName);
 					}
 					break;
 				case PDB::CodeView::TPI::TypeRecordKind::LF_BITFIELD:
 					if (typeName)
 					{
-						printf("[0x%X]%s %s : %d\n",
+						Printf("[0x%X]%s %s : %d\n",
 							offset,
 							typeName,
 							leafName,
@@ -700,7 +710,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 						if (!modifierRecord)
 							break;
 
-						printf("[0x%X]%s %s %s : %d\n",
+						Printf("[0x%X]%s %s %s : %d\n",
 							offset,
 							GetModifierName(modifierRecord),
 							GetTypeName(typeTable, modifierRecord->data.LF_MODIFIER.type, pointerLevel, nullptr, nullptr),
@@ -711,7 +721,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 				case PDB::CodeView::TPI::TypeRecordKind::LF_ARRAY:
 					if (!modifierRecord)
 					{
-						printf("[0x%X]%s %s[] /*0x%X*/\n",
+						Printf("[0x%X]%s %s[] /*0x%X*/\n",
 							offset,
 							typeName,
 							leafName,
@@ -719,7 +729,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 					}
 					else
 					{
-						printf("[0x%X]%s %s %s[] /*0x%X*/\n",
+						Printf("[0x%X]%s %s %s[] /*0x%X*/\n",
 							offset,
 							GetModifierName(modifierRecord),
 							GetTypeName(typeTable, modifierRecord->data.LF_MODIFIER.type, pointerLevel, nullptr, nullptr),
@@ -734,9 +744,9 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			else
 			{
 				if (modifierRecord)
-					printf("[0x%X]%s %s %s\n", offset, GetModifierName(modifierRecord), typeName, leafName);
+					Printf("[0x%X]%s %s %s\n", offset, GetModifierName(modifierRecord), typeName, leafName);
 				else
-					printf("[0x%X]%s %s\n", offset, typeName, leafName);
+					Printf("[0x%X]%s %s\n", offset, typeName, leafName);
 			}
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_NESTTYPE)
@@ -744,7 +754,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			leafName = &fieldRecord->data.LF_NESTTYPE.name[0];
 			typeName = GetTypeName(typeTable, fieldRecord->data.LF_NESTTYPE.index, pointerLevel, &referencedType, &modifierRecord);
 
-			printf("%s %s\n", typeName, leafName);
+			Printf("%s %s\n", typeName, leafName);
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_STMEMBER)
 		{
@@ -752,9 +762,9 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			typeName = GetTypeName(typeTable, fieldRecord->data.LF_STMEMBER.index, pointerLevel, &referencedType, &modifierRecord);
 
 			if (!modifierRecord)
-				printf("%s %s\n", typeName, leafName);
+				Printf("%s %s\n", typeName, leafName);
 			else
-				printf("%s %s %s\n", GetModifierName(modifierRecord), typeName, leafName);
+				Printf("%s %s %s\n", GetModifierName(modifierRecord), typeName, leafName);
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_METHOD)
 		{
@@ -772,8 +782,8 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 				if (!GetMethodPrototype(typeTable, typeTable.GetTypeRecord(methodList->data.LF_METHODLIST.mList[j]), functionPrototype))
 					break;
 
-				printf(functionPrototype.c_str(), leafName);
-				printf("\n");
+				Printf(functionPrototype.c_str(), leafName);
+				Printf("\n");
 			}
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_ONEMETHOD)
@@ -787,8 +797,8 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			if (!GetMethodPrototype(typeTable, referencedType, functionPrototype))
 				break;
 
-			printf(functionPrototype.c_str(), leafName);
-			printf("\n");
+			Printf(functionPrototype.c_str(), leafName);
+			Printf("\n");
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_BCLASS)
 		{
@@ -931,7 +941,7 @@ static void DisplayEnumerates(const PDB::CodeView::TPI::Record* record, uint8_t 
 			break;
 		}
 
-		printf("%s = %" PRIu64 "\n", leafName, value);
+		Printf("%s = %" PRIu64 "\n", leafName, value);
 
 		i += static_cast<size_t>(leafName - reinterpret_cast<const char*>(fieldRecord));
 		i += strnlen(leafName, maximumSize - i - 1) + 1;
@@ -964,11 +974,11 @@ void ExampleTypes(const PDB::TPIStream& tpiStream)
 
 			auto leafName = GetLeafName(record->data.LF_CLASS.data, record->data.LF_CLASS.lfEasy.kind);
 
-			printf("struct %s\n{\n", leafName);
+			Printf("struct %s\n{\n", leafName);
 			
 			DisplayFields(typeTable, typeRecord);
 
-			printf("}\n");
+			Printf("}\n");
 		}
 		else if (record->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_UNION)
 		{
@@ -981,11 +991,11 @@ void ExampleTypes(const PDB::TPIStream& tpiStream)
 
 			auto leafName = GetLeafName(record->data.LF_UNION.data, static_cast<PDB::CodeView::TPI::TypeRecordKind>(0));
 
-			printf("union %s\n{\n", leafName);
+			Printf("union %s\n{\n", leafName);
 
 			DisplayFields(typeTable, typeRecord);
 
-			printf("}\n");
+			Printf("}\n");
 		}
 		else if (record->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_ENUM)
 		{
@@ -996,11 +1006,11 @@ void ExampleTypes(const PDB::TPIStream& tpiStream)
 			if (!typeRecord)
 				continue;
 
-			printf("enum %s\n{\n", record->data.LF_ENUM.name);
+			Printf("enum %s\n{\n", record->data.LF_ENUM.name);
 
 			DisplayEnumerates(typeRecord, GetLeafSize(static_cast<PDB::CodeView::TPI::TypeRecordKind>(record->data.LF_ENUM.utype)));
 
-			printf("}\n");
+			Printf("}\n");
 		}
 	}
 

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -315,7 +315,7 @@ static const char* GetTypeName(const TypeTable& typeTable, uint32_t typeIndex, u
 				}
 			}
 
-			return GetTypeName(typeTable, typeRecord->data.LF_POINTER.utype, pointerLevel, &typeRecord, modifierRecord);		
+			return GetTypeName(typeTable, typeRecord->data.LF_POINTER.utype, pointerLevel, &typeRecord, modifierRecord);
 		case PDB::CodeView::TPI::TypeRecordKind::LF_PROCEDURE:
 			if (referencedType)
 				*referencedType = typeRecord;

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -249,6 +249,28 @@ static const char* GetTypeName(const TypeTable& typeTable, uint32_t typeIndex, u
 		case PDB::CodeView::TPI::TypeIndexKind::T_64PINT8:
 			return "PINT8";
 
+		case PDB::CodeView::TPI::TypeIndexKind::T_OCT:
+			return "OCTAL";
+
+		case PDB::CodeView::TPI::TypeIndexKind::T_POCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_PFOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_PHOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_32POCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_32PFOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_64POCT:
+			return "POCTAL";
+
+		case PDB::CodeView::TPI::TypeIndexKind::T_UOCT:
+			return "UOCTAL";
+
+		case PDB::CodeView::TPI::TypeIndexKind::T_PUOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_PFUOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_PHUOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_32PUOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_32PFUOCT:
+		case PDB::CodeView::TPI::TypeIndexKind::T_64PUOCT:
+			return "PUOCTAL";
+
 		default:
 			PDB_ASSERT(false, "Unhandled special type %u", typeIndex);
 			break;

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -663,6 +663,8 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 		// Other kinds of records are not implemented
 		PDB_ASSERT(
 			fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_BCLASS ||
+			fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_VBCLASS ||
+			fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_IVBCLASS ||
 			fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_INDEX ||
 			fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_VFUNCTAB ||
 			fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_NESTTYPE ||

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -304,6 +304,15 @@ static const char* GetTypeName(const TypeTable& typeTable, uint32_t typeIndex, u
 
 				if(underlyingType->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_POINTER)
 					return GetTypeName(typeTable, typeRecord->data.LF_POINTER.utype, pointerLevel, referencedType, modifierRecord);
+
+				// Type record order can be LF_POINTER -> LF_MODIFIER -> LF_POINTER -> ...
+				if (underlyingType->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_MODIFIER)
+				{
+					if (modifierRecord)
+						*modifierRecord = underlyingType;
+
+					return GetTypeName(typeTable, underlyingType->data.LF_MODIFIER.type, pointerLevel, referencedType, nullptr);
+				}
 			}
 
 			return GetTypeName(typeTable, typeRecord->data.LF_POINTER.utype, pointerLevel, &typeRecord, modifierRecord);		

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -91,6 +91,10 @@ static const char* GetTypeName(const TypeTable& typeTable, uint32_t typeIndex, u
 		case PDB::CodeView::TPI::TypeIndexKind::T_32PHRESULT:
 		case PDB::CodeView::TPI::TypeIndexKind::T_64PHRESULT:
 			return "PHRESULT";
+
+		case PDB::CodeView::TPI::TypeIndexKind::T_UNKNOWN_0600:
+			return "UNKNOWN_0x0600";
+
 		case PDB::CodeView::TPI::TypeIndexKind::T_VOID:
 			return "void";
 		case PDB::CodeView::TPI::TypeIndexKind::T_32PVOID:

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -306,9 +306,6 @@ static const char* GetTypeName(const TypeTable& typeTable, uint32_t typeIndex, u
 					return GetTypeName(typeTable, typeRecord->data.LF_POINTER.utype, pointerLevel, referencedType, modifierRecord);
 			}
 
-			if (referencedType)
-				*referencedType = typeRecord;
-
 			return GetTypeName(typeTable, typeRecord->data.LF_POINTER.utype, pointerLevel, &typeRecord, modifierRecord);		
 		case PDB::CodeView::TPI::TypeRecordKind::LF_PROCEDURE:
 			if (referencedType)

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -845,6 +845,22 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			i = (i + (sizeof(uint32_t) - 1)) & (0 - sizeof(uint32_t));
 			continue;
 		}
+		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_VBCLASS || fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_IVBCLASS)
+		{
+			// virtual base pointer offset from address point
+			// followed by virtual base offset from vbtable
+
+			const  PDB::CodeView::TPI::TypeRecordKind vbpOffsetAddressPointKind = *(PDB::CodeView::TPI::TypeRecordKind*)(fieldRecord->data.LF_IVBCLASS.vbpOffset);
+			const uint8_t vbpOffsetAddressPointSize = GetLeafSize(vbpOffsetAddressPointKind);
+
+			const  PDB::CodeView::TPI::TypeRecordKind vbpOffsetVBTableKind = *(PDB::CodeView::TPI::TypeRecordKind*)(fieldRecord->data.LF_IVBCLASS.vbpOffset + vbpOffsetAddressPointSize);
+			const uint8_t vbpOffsetVBTableSize = GetLeafSize(vbpOffsetVBTableKind);
+
+			i += sizeof(PDB::CodeView::TPI::FieldList::Data::LF_VBCLASS);
+			i += vbpOffsetAddressPointSize + vbpOffsetVBTableSize;
+			i = (i + (sizeof(uint32_t) - 1)) & (0 - sizeof(uint32_t));
+			continue;
+		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_INDEX)
 		{
 			i += sizeof(PDB::CodeView::TPI::FieldList::Data::LF_INDEX);

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -272,8 +272,8 @@ static const char* GetTypeName(const TypeTable& typeTable, uint32_t typeIndex, u
 			return "PUOCTAL";
 
 		default:
-			PDB_ASSERT(false, "Unhandled special type %u", typeIndex);
-			break;
+			PDB_ASSERT(false, "Unhandled special type 0x%X", typeIndex);
+			return "unhandled_special_type";
 		}
 	}
 	else

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -18,16 +18,6 @@ PDB_DISABLE_WARNING_CLANG("-Wformat-nonliteral")
 
 std::string GetTypeName(const TypeTable& typeTable, uint32_t typeIndex);
 
-static void Printf(const char* format, ...) 
-{
-	va_list args;
-	va_start(args, format);
-
-	vprintf(format, args);
-
-	va_end(args);
-}
-
 static uint8_t GetLeafSize(PDB::CodeView::TPI::TypeRecordKind kind)
 {
 	if (kind < PDB::CodeView::TPI::TypeRecordKind::LF_NUMERIC)
@@ -55,7 +45,7 @@ static uint8_t GetLeafSize(PDB::CodeView::TPI::TypeRecordKind kind)
 		return sizeof(PDB::CodeView::TPI::TypeRecordKind) + sizeof(uint64_t);
 
 	default:
-		Printf("Error! 0x%04x bogus type encountered, aborting...\n", PDB_AS_UNDERLYING(kind));
+		printf("Error! 0x%04x bogus type encountered, aborting...\n", PDB_AS_UNDERLYING(kind));
 	}
 	return 0;
 }
@@ -700,44 +690,44 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 						if (underlyingType->header.kind != PDB::CodeView::TPI::TypeRecordKind::LF_PROCEDURE)
 						{
 							if (modifierRecord)
-								Printf("[0x%X]%s %s", offset, GetModifierName(modifierRecord), typeName);
+								printf("[0x%X]%s %s", offset, GetModifierName(modifierRecord), typeName);
 							else
-								Printf("[0x%X]%s", offset, typeName);
+								printf("[0x%X]%s", offset, typeName);
 
 							for (size_t j = 0; j < pointerLevel; j++)
-								Printf("*");
+								printf("*");
 
-							Printf(" %s\n", leafName);
+							printf(" %s\n", leafName);
 						}
 						else
 						{
 							if (!GetFunctionPrototype(typeTable, underlyingType, functionPrototype))
 								break;
 
-							Printf("[0x%X]", offset);
-							Printf(functionPrototype.c_str(), leafName);
-							Printf("\n");
+							printf("[0x%X]", offset);
+							printf(functionPrototype.c_str(), leafName);
+							printf("\n");
 						}
 					}
 					else
 					{
-						Printf("[0x%X]%s", offset, typeName);
+						printf("[0x%X]%s", offset, typeName);
 
 						for (size_t j = 0; j < pointerLevel; j++)
-							Printf("*");
+							printf("*");
 
 						if (referencedType->data.LF_POINTER.attr.isvolatile)
-							Printf(" volatile");
+							printf(" volatile");
 						else if (referencedType->data.LF_POINTER.attr.isconst)
-							Printf(" const");
+							printf(" const");
 
-						Printf(" %s\n", leafName);
+						printf(" %s\n", leafName);
 					}
 					break;
 				case PDB::CodeView::TPI::TypeRecordKind::LF_BITFIELD:
 					if (typeName)
 					{
-						Printf("[0x%X]%s %s : %d\n",
+						printf("[0x%X]%s %s : %d\n",
 							offset,
 							typeName,
 							leafName,
@@ -749,7 +739,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 						if (!modifierRecord)
 							break;
 
-						Printf("[0x%X]%s %s %s : %d\n",
+						printf("[0x%X]%s %s %s : %d\n",
 							offset,
 							GetModifierName(modifierRecord),
 							GetTypeName(typeTable, modifierRecord->data.LF_MODIFIER.type, pointerLevel, nullptr, nullptr),
@@ -760,7 +750,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 				case PDB::CodeView::TPI::TypeRecordKind::LF_ARRAY:
 					if (!modifierRecord)
 					{
-						Printf("[0x%X]%s %s[] /*0x%X*/\n",
+						printf("[0x%X]%s %s[] /*0x%X*/\n",
 							offset,
 							typeName,
 							leafName,
@@ -768,7 +758,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 					}
 					else
 					{
-						Printf("[0x%X]%s %s %s[] /*0x%X*/\n",
+						printf("[0x%X]%s %s %s[] /*0x%X*/\n",
 							offset,
 							GetModifierName(modifierRecord),
 							GetTypeName(typeTable, modifierRecord->data.LF_MODIFIER.type, pointerLevel, nullptr, nullptr),
@@ -783,9 +773,9 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			else
 			{
 				if (modifierRecord)
-					Printf("[0x%X]%s %s %s\n", offset, GetModifierName(modifierRecord), typeName, leafName);
+					printf("[0x%X]%s %s %s\n", offset, GetModifierName(modifierRecord), typeName, leafName);
 				else
-					Printf("[0x%X]%s %s\n", offset, typeName, leafName);
+					printf("[0x%X]%s %s\n", offset, typeName, leafName);
 			}
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_NESTTYPE)
@@ -793,7 +783,7 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			leafName = &fieldRecord->data.LF_NESTTYPE.name[0];
 			typeName = GetTypeName(typeTable, fieldRecord->data.LF_NESTTYPE.index, pointerLevel, &referencedType, &modifierRecord);
 
-			Printf("%s %s\n", typeName, leafName);
+			printf("%s %s\n", typeName, leafName);
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_STMEMBER)
 		{
@@ -801,9 +791,9 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			typeName = GetTypeName(typeTable, fieldRecord->data.LF_STMEMBER.index, pointerLevel, &referencedType, &modifierRecord);
 
 			if (!modifierRecord)
-				Printf("%s %s\n", typeName, leafName);
+				printf("%s %s\n", typeName, leafName);
 			else
-				Printf("%s %s %s\n", GetModifierName(modifierRecord), typeName, leafName);
+				printf("%s %s %s\n", GetModifierName(modifierRecord), typeName, leafName);
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_METHOD)
 		{
@@ -821,8 +811,8 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 				if (!GetMethodPrototype(typeTable, typeTable.GetTypeRecord(methodList->data.LF_METHODLIST.mList[j]), functionPrototype))
 					break;
 
-				Printf(functionPrototype.c_str(), leafName);
-				Printf("\n");
+				printf(functionPrototype.c_str(), leafName);
+				printf("\n");
 			}
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_ONEMETHOD)
@@ -836,8 +826,8 @@ static void DisplayFields(const TypeTable& typeTable, const PDB::CodeView::TPI::
 			if (!GetMethodPrototype(typeTable, referencedType, functionPrototype))
 				break;
 
-			Printf(functionPrototype.c_str(), leafName);
-			Printf("\n");
+			printf(functionPrototype.c_str(), leafName);
+			printf("\n");
 		}
 		else if (fieldRecord->kind == PDB::CodeView::TPI::TypeRecordKind::LF_BCLASS)
 		{
@@ -996,7 +986,7 @@ static void DisplayEnumerates(const PDB::CodeView::TPI::Record* record, uint8_t 
 			break;
 		}
 
-		Printf("%s = %" PRIu64 "\n", leafName, value);
+		printf("%s = %" PRIu64 "\n", leafName, value);
 
 		i += static_cast<size_t>(leafName - reinterpret_cast<const char*>(fieldRecord));
 		i += strnlen(leafName, maximumSize - i - 1) + 1;
@@ -1029,11 +1019,11 @@ void ExampleTypes(const PDB::TPIStream& tpiStream)
 
 			auto leafName = GetLeafName(record->data.LF_CLASS.data, record->data.LF_CLASS.lfEasy.kind);
 
-			Printf("struct %s\n{\n", leafName);
+			printf("struct %s\n{\n", leafName);
 			
 			DisplayFields(typeTable, typeRecord);
 
-			Printf("}\n");
+			printf("}\n");
 		}
 		else if (record->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_UNION)
 		{
@@ -1046,11 +1036,11 @@ void ExampleTypes(const PDB::TPIStream& tpiStream)
 
 			auto leafName = GetLeafName(record->data.LF_UNION.data, static_cast<PDB::CodeView::TPI::TypeRecordKind>(0));
 
-			Printf("union %s\n{\n", leafName);
+			printf("union %s\n{\n", leafName);
 
 			DisplayFields(typeTable, typeRecord);
 
-			Printf("}\n");
+			printf("}\n");
 		}
 		else if (record->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_ENUM)
 		{
@@ -1061,11 +1051,11 @@ void ExampleTypes(const PDB::TPIStream& tpiStream)
 			if (!typeRecord)
 				continue;
 
-			Printf("enum %s\n{\n", record->data.LF_ENUM.name);
+			printf("enum %s\n{\n", record->data.LF_ENUM.name);
 
 			DisplayEnumerates(typeRecord, GetLeafSize(static_cast<PDB::CodeView::TPI::TypeRecordKind>(record->data.LF_ENUM.utype)));
 
-			Printf("}\n");
+			printf("}\n");
 		}
 	}
 

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -120,7 +120,7 @@ namespace PDB
 			enum class PDB_NO_DISCARD SymbolRecordKind : uint16_t
 			{
 				S_END =										0x0006u,		// block, procedure, "with" or thunk end
-				S_SKIP =                                    0x0007u,        // Reserve symbol space in $$Symbols table
+				S_SKIP =									0x0007u,        // Reserve symbol space in $$Symbols table
 				S_FRAMEPROC =								0x1012u,		// extra frame and proc information
 				S_OBJNAME =									0x1101u,		// full path to the original compiled .obj. can point to remote locations and temporary files, not necessarily the file that was linked into the executable
 				S_THUNK32 =									0x1102u,		// thunk start
@@ -166,7 +166,7 @@ namespace PDB
 				S_HEAPALLOCSITE = 							0x115Eu,		// heap allocation site
 				S_INLINEES =			 					0x1168u,		// https://llvm.org/docs/PDB/CodeViewSymbols.html#s-inlinees-0x1168
 				S_REGREL32_INDIR =							0x1171u,
-				S_REGREL32_ENCTMP =                         0x1179u,
+				S_REGREL32_ENCTMP =							0x1179u,
 				S_UDT =										0x1108u,		// user-defined type
 				S_UDT_ST =									0x1003u,		// user-defined structured types
 			};

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -120,6 +120,7 @@ namespace PDB
 			enum class PDB_NO_DISCARD SymbolRecordKind : uint16_t
 			{
 				S_END =										0x0006u,		// block, procedure, "with" or thunk end
+				S_SKIP =                                    0x0007u,        // Reserve symbol space in $$Symbols table
 				S_FRAMEPROC =								0x1012u,		// extra frame and proc information
 				S_OBJNAME =									0x1101u,		// full path to the original compiled .obj. can point to remote locations and temporary files, not necessarily the file that was linked into the executable
 				S_THUNK32 =									0x1102u,		// thunk start

--- a/src/PDB_TPITypes.h
+++ b/src/PDB_TPITypes.h
@@ -148,7 +148,7 @@ namespace PDB
 				T_64PHRESULT = 0x0608u,			// OLE/COM HRESULT __ptr64 *
 
 				// Emitted due to a compiler bug? 
-				// 0x0600 bit appears to indicate a 64-bit pointer, but it has no type?
+				// 0x0600 bits appears to indicate a 64-bit pointer, but it has no type?
 				// Seen as type index for C11 "_Atomic uint32_t*" variable and constant.
 				T_UNKNOWN_0600 = 0x0600u,
 

--- a/src/PDB_TPITypes.h
+++ b/src/PDB_TPITypes.h
@@ -600,8 +600,16 @@ namespace PDB
 						};
 					}LF_BCLASS;
 
-					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2483
+					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2521
+					struct
+					{
+						MemberAttributes	attributes;	// attribute
+						uint32_t			index;		// type index of direct virtual base class
+						uint32_t			vbpIndex;   // type index of virtual base pointer
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, vbpOffset); // virtual base pointer offset from address point
+					} LF_VBCLASS, LF_IVBCLASS;
 
+					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2483
 					// index leaf - contains type index of another leaf
 					// a major use of this leaf is to allow the compilers to emit a
 					// long complex list (LF_FIELD) in smaller pieces.

--- a/src/PDB_TPITypes.h
+++ b/src/PDB_TPITypes.h
@@ -148,7 +148,7 @@ namespace PDB
 				T_64PHRESULT = 0x0608u,			// OLE/COM HRESULT __ptr64 *
 
 				// Emitted due to a compiler bug? 
-				// 0x0600 bit appears to indicate a 64-bit pointer, but it has not type?
+				// 0x0600 bit appears to indicate a 64-bit pointer, but it has no type?
 				// Seen as type index for C11 "_Atomic uint32_t*" variable and constant.
 				T_UNKNOWN_0600 = 0x0600u,
 

--- a/src/PDB_TPITypes.h
+++ b/src/PDB_TPITypes.h
@@ -147,6 +147,11 @@ namespace PDB
 				T_32PHRESULT = 0x0408u,			// OLE/COM HRESULT __ptr32 *
 				T_64PHRESULT = 0x0608u,			// OLE/COM HRESULT __ptr64 *
 
+				// Emitted due to a compiler bug? 
+				// 0x0600 bit appears to indicate a 64-bit pointer, but it has not type?
+				// Seen as type index for C11 "_Atomic uint32_t*" variable and constant.
+				T_UNKNOWN_0600 = 0x0600u,
+
 				T_PVOID = 0x0103u,				// near pointer to void
 				T_PFVOID = 0x0203u,				// far pointer to void
 				T_PHVOID = 0x0303u,				// huge pointer to void


### PR DESCRIPTION
Fixes issue https://github.com/MolecularMatters/raw_pdb/issues/32 and https://github.com/MolecularMatters/raw_pdb/issues/59

In the chrome.dll.pdb there is a type with type index 0x0600, which looks like a compiler bug to me.

I believe I correctly tracked down the code for one of the places it was used. 

Output from function variables example:

```
S_LOCAL: 'PUINT' -> 'in_count'
S_CONSTANT: 'UNKNOWN_0x0600' -> 'ªªªªªªªªcount' | Value 0x8009
S_CONSTANT: 'UINT' -> 'ªªªªexpected' | Value 0x8003
S_CONSTANT: 'UINT' -> 'ªªªªnew_value' | Value 0x8003
```

Code:

```C
// Type definition
typedef _Atomic uint32_t CRYPTO_atomic_u32;

// Function
void CRYPTO_refcount_inc(CRYPTO_refcount_t *in_count) {
  CRYPTO_atomic_u32 *count = (CRYPTO_atomic_u32 *)in_count;
  uint32_t expected = CRYPTO_atomic_load_u32(count);

  while (expected != CRYPTO_REFCOUNT_MAX) {
    uint32_t new_value = expected + 1;
    if (CRYPTO_atomic_compare_exchange_weak_u32(count, &expected, new_value)) {
      break;
    }
  }
}
```

It looks to me like the compiler is not emitting the type indices correctly for C11 _Atomic types. Also note that the variables are incorrectly emitted as `S_CONSTANT`, which looks like a potential logic error due to type index 0x0600 being emitted before it. I think the "ªªªª" (0xAAAAAAAA) prefix is some special prefix due to this function being inlined in this case.

I successfully tested this branch with 659 different PDBs with a total size of 21.4 GiB in release build with asserts enabled.

See [raw_pdb_test_output.txt](https://github.com/MolecularMatters/raw_pdb/files/12669852/raw_pdb_test_output.txt) for output results of [raw_pdb_test.bat](https://github.com/MolecularMatters/raw_pdb/files/12669858/raw_pdb_test.bat.txt) (attached with .txt extension)