### PR TITLE
Add option to toggle building the examples

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,11 @@ target_precompile_headers(raw_pdb
     PDB_PCH.h
 )
 
-add_subdirectory(Examples)
+option(RAWPDB_BUILD_EXAMPLES "Build Examples" ON)
+
+if (RAWPDB_BUILD_EXAMPLES)
+	add_subdirectory(Examples)
+endif()
 
 if (UNIX)
 	include(GNUInstallDirs)

--- a/src/Examples/Examples_PCH.h
+++ b/src/Examples/Examples_PCH.h
@@ -29,4 +29,5 @@
 #	include <chrono>
 #	include <string>
 #	include <algorithm>
+#	include <cstdarg>
 #	include "Foundation/PDB_DisableWarningsPop.h"


### PR DESCRIPTION
Hi, first of all thank you for this brilliant library, I was able to parse pdb in a matter of minutes on linux, the api is self explanatory and the examples are helpful.

There is currently no way to skip building the examples.
I saw in https://github.com/MolecularMatters/raw_pdb/pull/48#issuecomment-1634166028 that the examples should always be built, but having to constantly rebuild the examples is time consuming, hence why having an option to skip them which is **off by default**, would be nice.

I also fixed a build error in `ExampleFunctionVariables.cpp`
```
src/Examples/ExampleFunctionVariables.cpp:33:9: error: ‘va_start’ was not declared in this scope
   33 |         va_start(args, format);
      |         ^~~~~~~~
src/Examples/ExampleFunctionVariables.cpp:38:9: error: ‘va_end’ was not declared in this scope
   38 |         va_end(args);
      |         ^~~~~~
```
which occurs on Debian 12 bookworm with gcc 12.2.0