### PR TITLE
TPI size example

### DIFF
--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -78,6 +78,7 @@ namespace
 
 // declare all examples
 extern void ExamplePDBSize(const PDB::RawFile&, const PDB::DBIStream&);
+extern void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath);
 extern void ExampleContributions(const PDB::RawFile&, const PDB::DBIStream&);
 extern void ExampleSymbols(const PDB::RawFile&, const PDB::DBIStream&);
 extern void ExampleFunctionSymbols(const PDB::RawFile&, const PDB::DBIStream&);
@@ -160,6 +161,8 @@ int main(int argc, char** argv)
 	ExampleFunctionVariables(rawPdbFile, dbiStream, tpiStream);
 	ExampleLines(rawPdbFile, dbiStream, infoStream);
 	ExampleTypes(tpiStream);
+	// uncomment to dump type sizes to a CSV
+	// ExampleTPISize(tpiStream, "output.csv");
 
 	MemoryMappedFile::Close(pdbFile);
 

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -1260,8 +1260,6 @@ static void TagRecursively(const TypeTable& typeTable, uint32_t typeIndex, T set
 //and insight.
 //
 // The Name is set to "???" if no name was found, and it is set to "!!!" if multiple names reference the entry.
-//
-// Note, type records are not written out in order, so you cannot rely on their indices.
 void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath);
 void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 {
@@ -1314,11 +1312,7 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 		PDB::CodeView::TPI::TypeRecordKind kind = record->header.kind;
 		if (kind == PDB::CodeView::TPI::TypeRecordKind::LF_STRUCTURE)
 		{
-			fprintf(f, "%hu;", 2 + record->header.size);
-			fprintf(f, "LF_STRUCTURE;");
 			names[i] = GetLeafName(record->data.LF_CLASS.data, record->data.LF_CLASS.lfEasy.kind);
-			fprintf(f, names[i]);
-			fprintf(f, "\n");
 			auto setName = [&setNameGlobal, name = names[i]](uint32_t typeIndex) -> bool {
 				return setNameGlobal(typeIndex, name);
 			};
@@ -1326,11 +1320,7 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 		}
 		else if (kind == PDB::CodeView::TPI::TypeRecordKind::LF_CLASS)
 		{
-			fprintf(f, "%hu;", 2 + record->header.size);
-			fprintf(f, "LF_CLASS;");
 			names[i] = GetLeafName(record->data.LF_CLASS.data, record->data.LF_CLASS.lfEasy.kind);
-			fprintf(f, names[i]);
-			fprintf(f, "\n");
 			auto setName = [&setNameGlobal, name = names[i]](uint32_t typeIndex) -> bool {
 				return setNameGlobal(typeIndex, name);
 			};
@@ -1338,11 +1328,7 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 		}
 		else if (kind == PDB::CodeView::TPI::TypeRecordKind::LF_UNION)
 		{
-			fprintf(f, "%hu;", 2 + record->header.size);
-			fprintf(f, "LF_UNION;");
 			names[i] = GetLeafName(record->data.LF_UNION.data, static_cast<PDB::CodeView::TPI::TypeRecordKind>(0));
-			fprintf(f, names[i]);
-			fprintf(f, "\n");
 			auto setName = [&setNameGlobal, name = names[i]](uint32_t typeIndex) -> bool {
 				return setNameGlobal(typeIndex, name);
 			};
@@ -1350,9 +1336,7 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 		}
 		else if (kind == PDB::CodeView::TPI::TypeRecordKind::LF_ENUM)
 		{
-			fprintf(f, "%hu;", 2 + record->header.size);
 			names[i] = record->data.LF_ENUM.name;
-			fprintf(f, "LF_ENUM;%s\n", names[i]);
 			auto setName = [&setNameGlobal, name = names[i]](uint32_t typeIndex) -> bool {
 				return setNameGlobal(typeIndex, name);
 			};
@@ -1360,7 +1344,6 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 		}
 		else if (kind == PDB::CodeView::TPI::TypeRecordKind::LF_MFUNCTION)
 		{
-			fprintf(f, "%hu;", 2 + record->header.size);
 			const char* name = names[i];
 			if (!name)
 			{
@@ -1375,7 +1358,6 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 						PDB_ASSERT(false, "unsupported");
 				}
 			}
-			fprintf(f, "LF_MFUNCTION;%s\n", name);
 			auto setName = [&setNameGlobal, name = name](uint32_t typeIndex) -> bool {
 				return setNameGlobal(typeIndex, name);
 			};
@@ -1387,18 +1369,6 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 	for (size_t i = 0, n = typeRecords.GetLength(); i < n; i++)
 	{
 		const PDB::CodeView::TPI::Record* record = typeRecords[i];
-		PDB::CodeView::TPI::TypeRecordKind kind = record->header.kind;
-		if (kind == PDB::CodeView::TPI::TypeRecordKind::LF_STRUCTURE ||
-			kind == PDB::CodeView::TPI::TypeRecordKind::LF_CLASS ||
-			kind == PDB::CodeView::TPI::TypeRecordKind::LF_UNION ||
-			kind == PDB::CodeView::TPI::TypeRecordKind::LF_ENUM ||
-			kind == PDB::CodeView::TPI::TypeRecordKind::LF_MFUNCTION)
-		{
-			// handled above;
-			continue;
-		}
-
-		fprintf(f, "%hu;", 2 + record->header.size);
 		const char* kindName = nullptr;
 		const char* typeName = i < names.size() ? names[i] : nullptr;
 		switch (record->header.kind)
@@ -1414,9 +1384,15 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 			case PDB::CodeView::TPI::TypeRecordKind::LF_METHODLIST: kindName = "LF_METHODLIST;"; break;
 			case PDB::CodeView::TPI::TypeRecordKind::LF_ARRAY: kindName = "LF_ARRAY;"; break;
 			case PDB::CodeView::TPI::TypeRecordKind::LF_PRECOMP: kindName = "LF_PRECOMP;"; break;
+			case PDB::CodeView::TPI::TypeRecordKind::LF_MFUNCTION: kindName = "LF_MFUNCTION;"; break;
+			case PDB::CodeView::TPI::TypeRecordKind::LF_STRUCTURE: kindName = "LF_STRUCTURE;"; break;
+			case PDB::CodeView::TPI::TypeRecordKind::LF_CLASS: kindName = "LF_CLASS;"; break;
+			case PDB::CodeView::TPI::TypeRecordKind::LF_UNION: kindName = "LF_UNION;"; break;
+			case PDB::CodeView::TPI::TypeRecordKind::LF_ENUM: kindName = "LF_ENUM;"; break;
 			default: break;
 		}
 
+		fprintf(f, "%hu;", 2 + record->header.size);
 		if (kindName)
 			fprintf(f, kindName);
 		else

--- a/src/Foundation/PDB_ArrayView.h
+++ b/src/Foundation/PDB_ArrayView.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "PDB_Macros.h"
+#include "PDB_Assert.h"
 
 
 namespace PDB

--- a/src/PDB_TPITypes.h
+++ b/src/PDB_TPITypes.h
@@ -684,6 +684,15 @@ namespace PDB
 				} data;
 			};
 
+			// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2131
+			struct MethodListEntry
+			{
+				MemberAttributes attributes;					// method attribute
+				uint16_t		pad0;							// internal padding, must be 0
+				uint32_t		index;							// index to type record for procedure
+				PDB_FLEXIBLE_ARRAY_MEMBER(uint32_t, vbaseoff);	// offset in vfunctable if virtual, empty otherwise.
+			};
+
 			// all CodeView records are stored as a header, followed by variable-length data.
 			// internal Record structs such as S_PUB32, S_GDATA32, etc. correspond to the data layout of a CodeView record of that kind.
 			struct Record
@@ -695,17 +704,10 @@ namespace PDB
 					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2144
 					struct
 					{
-						PDB_FLEXIBLE_ARRAY_MEMBER(uint32_t, mList);
+						// This is actually a list of the MethodListEntry type above, but it has flexible
+						// size, so you need to manually iterate.
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, mList);
 					} LF_METHODLIST;
-
-					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2131
-					struct
-					{
-						MemberAttributes attributes;					// method attribute
-						uint16_t		pad0;							// internal padding, must be 0
-						uint32_t		index;							// index to type record for procedure
-						PDB_FLEXIBLE_ARRAY_MEMBER(uint32_t, vbaseoff);	// offset in vfunctable if
-					} METHOD;
 
 					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L1801
 					struct

--- a/src/PDB_TPITypes.h
+++ b/src/PDB_TPITypes.h
@@ -615,9 +615,8 @@ namespace PDB
 					// long complex list (LF_FIELD) in smaller pieces.
 					struct
 					{
-						uint16_t leaf; // LF_INDEX
 						uint16_t pad0; // internal padding, must be 0
-						uint16_t type; // type index of referenced leaf
+						uint32_t type; // type index of referenced leaf
 					} LF_INDEX;
 
 					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L2615


### PR DESCRIPTION
This PR contains three small fixes and a new example. I have been working with large PDBs and needed to understand what makes up the TPI stream, which is what the example is about. Yes, I know it would be great to split this into three PRs, but my days are long and my freetime is short :)

Fixes:
 - Add missing include in PDB_ArrayView. Self-explanatory. Not sure why it broke since the project should be using PCHs anyway, but I have observed this failure a few times locally.
 -  Correct broken `LF_INDEX` type. The `LF_INDEX` type has a `uint16_t leaf` member as its first member according to Microsoft, but that's actually something that _all_ of the structs that are within the `FieldList` struct have. So RawPDB made the sensible choice of moving it out of the inner struct into the outer struct (that's `FieldList::kind`). The `uint16_t leaf` member was removed from all other structs except for the `LF_INDEX` one where someone probably forgot to remove it. I did that now. -- This error probably didn't show up until now because usage of the `LF_INDEX` type is super rare. The compiler will only emit an `LF_INDEX` type if there is a type that has so many members that they don't fit into a single `FieldList` (64k limit). Then it will emit an `LF_INDEX` in the first `FieldList` to link to the next and so on. You can replicate that by having a type with many nested types, for example.
 - Fix usage of `LF_METHODLIST`. The `FieldList` contains all the different members of a type, and for methods it contains an `LF_METHOD` entry that links to a `LF_METHODLIST` describing the overload set for that method (all methods with a common type). Before this PR, the data in `LF_METHODLIST` was treated like an array of `uint32_t` (assumed to be type indices) with a check for validity that often fails. However, that's not how this data should be interpreted. Instead, there is a separate type for the entries in the list (that type already existed in the codebase, but was unused). The challenge is that the type has variable size: Whether or not the last member exists depends on an attribute in the struct instance itself. This misinterpretation bug meant that we were previously skipping between 50% and 66% of member functions when traversing types in the examples (and produced a bunch of bogus data as well). The way that the name for the `LF_METHOD` kind was read was also wrong (looked like a copy-pasta error), which could misalign the streams in the example.

All of these fixes (and the examples below) have been verified extensively on literal gigabytes of PDBs. These bugs have caused invalid kinds to show up in some of my examples and they are all gone now -- furthermore, fixing the bugs has greatly improved the coverage of my example, explained below.

### TPI Size Example
The example I wrote is a variation on the types examples but with a different focus. The question I am trying to answer is "how much memory does every type take up in the TPI stream?" This question becomes relevant if your TPI stream grows very big. The example computes information to help answer this question and then writes it out to a CSV file that contains the kind, size, and associated type for every TPI stream codeview record.

The strategy is fairly straight forward:
 * For every class, struct, union, or enum mark it with its own name.
 * Then recursively go down the members and mark all members with that name as well -- do not recurse into other types.
 * If an entry already has a name, set the name to the marker `!!!` which indicates that the record is shared by many.
 * Then go through all records and dump them out with their name. If no name was set, use `???`.

There's also a special-case for `LF_MFUNCTION` because member-functions store their enclosing type, so it is perfectly possible for a compiler to emit this and not reference it somewhere else, yet we can still attribute it. (Without this clause, we end up with some unattributed `LF_MFUNCTION` records.)

The resulting CSV file can then be post-processed in a tool of your choice (e.g. group by typename and sum up sizes). In my case, I've found that I was able to attribute more than 99% of TPI stream size to types (including shared data marked as `!!!`). Only < 1% would end up as residual data. This residual data could either mean that there are still errors in the example or that there are types in the stream that are not transitively referenced by class/struct/union/enum types. An example could be the function-type of a free-standing (i.e. non-member) function.

To illustrate the residual, here are the unaccounted sizes (in bytes) from a PDB with a ~2GB TPI stream, broken down by kind:
```
unaccounted: 21,512,704
LF_PROCEDURE = 10,447,184
LF_ARGLIST = 6,928,460
LF_POINTER = 3,961,108
LF_ARRAY = 84,304
LF_VTSHAPE = 68,728
LF_MODIFIER = 22,920
```
My suspicion is that free-standing functions cause the 10MB of `LF_PROCEDURE` entries -- those then reference the `LF_ARGLIST` and explain the missing `LF_POINTER`/`LF_MODIFIER` that way. `LF_ARRAY` could be static free-standing arrays. `LF_VTSHAPE` isn't clear to me, but 68KiB in 2GB is irrelevant.