### PR TITLE
ExampleTypes: fix no format args

### DIFF
--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -1394,7 +1394,7 @@ void ExampleTPISize(const PDB::TPIStream& tpiStream, const char* outPath)
 
 		fprintf(f, "%hu;", 2 + record->header.size);
 		if (kindName)
-			fprintf(f, kindName);
+			fprintf(f, "%s;", kindName);
 		else
 			fprintf(f, "0x%04X;", (int)record->header.kind);
 


### PR DESCRIPTION
/raw_pdb/src/Examples/ExampleTypes.cpp:1397:32: warning: format not a string literal and no format arguments [-Wformat-security]
 1397 |                         fprintf(f, kindName);