### PR TITLE
ExamplePDBSize: fix %hs format string

### DIFF
--- a/src/Examples/ExamplePDBSize.cpp
+++ b/src/Examples/ExamplePDBSize.cpp
@@ -84,7 +84,7 @@ void ExamplePDBSize(const PDB::RawFile& rawPdbFile, const PDB::DBIStream& dbiStr
 			const uint16_t streamIndex = module.HasSymbolStream() ? moduleInfo->moduleSymbolStreamIndex : 0u;
 			const uint32_t moduleStreamSize = (streamIndex != 0u) ? rawPdbFile.GetStreamSize(streamIndex) : 0u;
 
-			printf("Module %hs (%hs) stream size: %u KiB (%u MiB)\n", name, objectName, moduleStreamSize >> 10u, moduleStreamSize >> 20u);
+			printf("Module %s (%s) stream size: %u KiB (%u MiB)\n", name, objectName, moduleStreamSize >> 10u, moduleStreamSize >> 20u);
 
 			streams.push_back(Stream { name, moduleStreamSize });
 		}


### PR DESCRIPTION
raw_pdb/src/Examples/ExamplePDBSize.cpp:87:42: warning: use of ‘h’ length modifier with ‘s’ type character has either no effect or undefined behavior [-Wformat=]
   87 |                         printf("Module %hs (%hs) stream size: %u KiB (%u MiB)\n", name, objectName, moduleStreamSize >> 10u, moduleStreamSize >> 20u);