### PR TITLE
CMakeLists.txt: require C++-14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(raw_pdb)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
GCC 13.2 says

raw_pdb/src/Examples/ExampleTypes.cpp:1316:57: warning: lambda capture initializers only available with ‘-std=c++14’ or ‘-std=gnu++14’ [-Wc++14-extensions]
 1316 |                         auto setName = [&setNameGlobal, name = names[i]](uint32_t typeIndex) -> bool {