### PR TITLE
Check the PDB data size & Initialize name stream

### DIFF
--- a/raw_pdb.natvis
+++ b/raw_pdb.natvis
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="PDB::ArrayView&lt;*&gt;">
+		<DisplayString>{{ size={m_length} }}</DisplayString>
+		<Expand>
+			<ArrayItems>
+				<Size>m_length</Size>
+				<ValuePointer>m_data</ValuePointer>
+			</ArrayItems>
+		</Expand>
+	</Type>
+</AutoVisualizer>

--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
 		return 1;
 	}
 
-	if (IsError(PDB::ValidateFile(pdbFile.baseAddress)))
+	if (IsError(PDB::ValidateFile(pdbFile.baseAddress, pdbFile.len)))
 	{
 		MemoryMappedFile::Close(pdbFile);
 

--- a/src/Examples/ExampleMemoryMappedFile.cpp
+++ b/src/Examples/ExampleMemoryMappedFile.cpp
@@ -12,7 +12,7 @@ MemoryMappedFile::Handle MemoryMappedFile::Open(const char* path)
 
 	if (file == INVALID_HANDLE_VALUE)
 	{
-		return Handle { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr };
+		return Handle { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr, 0 };
 	}
 
 	void* fileMapping = CreateFileMappingW(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
@@ -21,7 +21,7 @@ MemoryMappedFile::Handle MemoryMappedFile::Open(const char* path)
 	{
 		CloseHandle(file);
 
-		return Handle { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr };
+		return Handle { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr, 0 };
 	}
 
 	void* baseAddress = MapViewOfFile(fileMapping, FILE_MAP_READ, 0, 0, 0);
@@ -31,10 +31,22 @@ MemoryMappedFile::Handle MemoryMappedFile::Open(const char* path)
 		CloseHandle(fileMapping);
 		CloseHandle(file);
 
-		return Handle { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr };
+		return Handle { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr, 0 };
 	}
 
-	return Handle { file, fileMapping, baseAddress };
+	MEMORY_BASIC_INFORMATION memoryInfo;
+	const size_t queryResult = VirtualQuery(baseAddress, &memoryInfo, sizeof(memoryInfo));
+	if (queryResult == 0)
+	{
+		UnmapViewOfFile(baseAddress);
+		CloseHandle(fileMapping);
+		CloseHandle(file);
+
+		return Handle { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr, 0 };
+	}
+
+	const size_t fileSize = memoryInfo.RegionSize;
+	return Handle { file, fileMapping, baseAddress, fileSize };
 #else
 	struct stat fileSb;
 
@@ -61,7 +73,7 @@ MemoryMappedFile::Handle MemoryMappedFile::Open(const char* path)
 		return Handle { INVALID_HANDLE_VALUE, nullptr, 0 };
 	}
 
-	return Handle { file, baseAddress, fileSb.st_size };
+	return Handle { file, baseAddress, static_cast<size_t>(fileSb.st_size) };
 #endif
 }
 

--- a/src/Examples/ExampleMemoryMappedFile.h
+++ b/src/Examples/ExampleMemoryMappedFile.h
@@ -21,9 +21,7 @@ namespace MemoryMappedFile
 		int   file;
 #endif
 		void* baseAddress;
-#ifndef _WIN32
-		long len;
-#endif
+		size_t len;
 	};
 
 	Handle Open(const char* path);

--- a/src/PDB.cpp
+++ b/src/PDB.cpp
@@ -14,8 +14,13 @@
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-PDB_NO_DISCARD PDB::ErrorCode PDB::ValidateFile(const void* data) PDB_NO_EXCEPT
+PDB_NO_DISCARD PDB::ErrorCode PDB::ValidateFile(const void* data, size_t size) PDB_NO_EXCEPT
 {
+	// validate if there are enough bytes for the super block
+	if (size < sizeof(SuperBlock))
+	{
+		return ErrorCode::InvalidDataSize;
+	}
 	// validate the super block
 	const SuperBlock* superBlock = Pointer::Offset<const SuperBlock*>(data, 0u);
 	{
@@ -23,6 +28,13 @@ PDB_NO_DISCARD PDB::ErrorCode PDB::ValidateFile(const void* data) PDB_NO_EXCEPT
 		if (std::memcmp(superBlock->fileMagic, SuperBlock::MAGIC, sizeof(SuperBlock::MAGIC)) != 0)
 		{
 			return ErrorCode::InvalidSuperBlock;
+		}
+
+		// validate if there are enough bytes are provided
+		// blockCount * blockSize should equal the size of the file on disk
+		if (size < superBlock->blockCount * superBlock->blockSize)
+		{
+			return ErrorCode::InvalidDataSize;
 		}
 
 		// validate free block map.

--- a/src/PDB.cpp
+++ b/src/PDB.cpp
@@ -16,7 +16,7 @@
 // ------------------------------------------------------------------------------------------------
 PDB_NO_DISCARD PDB::ErrorCode PDB::ValidateFile(const void* data, size_t size) PDB_NO_EXCEPT
 {
-	// validate if there are enough bytes for the super block
+	// validate whether there is enough size for the super block
 	if (size < sizeof(SuperBlock))
 	{
 		return ErrorCode::InvalidDataSize;
@@ -30,8 +30,8 @@ PDB_NO_DISCARD PDB::ErrorCode PDB::ValidateFile(const void* data, size_t size) P
 			return ErrorCode::InvalidSuperBlock;
 		}
 
-		// validate if there are enough bytes are provided
-		// blockCount * blockSize should equal the size of the file on disk
+		// validate whether enough size is provided for the PDB file
+		// blockCount * blockSize is the size of the PDB file on disk
 		if (size < superBlock->blockCount * superBlock->blockSize)
 		{
 			return ErrorCode::InvalidDataSize;

--- a/src/PDB.h
+++ b/src/PDB.h
@@ -14,7 +14,7 @@ namespace PDB
 
 
 	// Validates whether a PDB file is valid.
-	PDB_NO_DISCARD ErrorCode ValidateFile(const void* data, size_t size = static_cast<size_t>(-1)) PDB_NO_EXCEPT;
+	PDB_NO_DISCARD ErrorCode ValidateFile(const void* data, size_t size) PDB_NO_EXCEPT;
 
 	// Creates a raw PDB file that must have been validated.
 	PDB_NO_DISCARD RawFile CreateRawFile(const void* data) PDB_NO_EXCEPT;

--- a/src/PDB.h
+++ b/src/PDB.h
@@ -14,7 +14,7 @@ namespace PDB
 
 
 	// Validates whether a PDB file is valid.
-	PDB_NO_DISCARD ErrorCode ValidateFile(const void* data) PDB_NO_EXCEPT;
+	PDB_NO_DISCARD ErrorCode ValidateFile(const void* data, size_t size = static_cast<size_t>(-1)) PDB_NO_EXCEPT;
 
 	// Creates a raw PDB file that must have been validated.
 	PDB_NO_DISCARD RawFile CreateRawFile(const void* data) PDB_NO_EXCEPT;

--- a/src/PDB_ErrorCodes.h
+++ b/src/PDB_ErrorCodes.h
@@ -13,6 +13,7 @@ namespace PDB
 		Success = 0u,
 
 		// main PDB validation
+		InvalidDataSize,
 		InvalidSuperBlock,
 		InvalidFreeBlockMap,
 

--- a/src/PDB_InfoStream.cpp
+++ b/src/PDB_InfoStream.cpp
@@ -29,6 +29,7 @@ PDB::InfoStream::InfoStream(void) PDB_NO_EXCEPT
 PDB::InfoStream::InfoStream(const RawFile& file) PDB_NO_EXCEPT
 	: m_stream(file.CreateMSFStream<CoalescedMSFStream>(InfoStreamIndex))
 	, m_header(m_stream.GetDataAtOffset<const Header>(0u))
+	, m_namesStreamIndex(0)
 	, m_usesDebugFastlink(false)
 {
 	// the info stream starts with the header, followed by the named stream map, followed by the feature codes


### PR DESCRIPTION
Hello, Folks!
I'm trying to use the `raw_pdb` library for parsing PDB files and have found several issues that I believe are worth fixing:
- I was concerned that during validation, the library didn't consider the actual size of the data. Therefore, I added an ability to check the data size during file validation.
- I found a minor bug: `InfoStream` constructor didn't initialize `m_namesStreamIndex`. As a result, when the PDB doesn't have a `"/names"` stream, it leads to garbage in `m_namesStreamIndex`, causing the method `InfoStream::HasNamesStream` to not work properly.
- I added a simple `Natvis` file for an array to make debugging easier. I think I could extend it further later on.

Please take a look.
Thanks!