### PR TITLE
Privatepdb fix

### DIFF
--- a/src/Examples/ExampleFunctionVariables.cpp
+++ b/src/Examples/ExampleFunctionVariables.cpp
@@ -125,7 +125,7 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 				}
 				else if (kind == SymbolRecordKind::S_DEFRANGE_REGISTER)
 				{
-					Printf(blockLevel, "S_DEFRANGE_REGISTER: Register 0x % X\n", data.S_DEFRANGE_REGISTER.reg);
+					Printf(blockLevel, "S_DEFRANGE_REGISTER: Register 0x%X\n", data.S_DEFRANGE_REGISTER.reg);
 				}
 				else if(kind == SymbolRecordKind::S_DEFRANGE_FRAMEPOINTER_REL)
 				{
@@ -212,6 +212,22 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 
 					Printf(blockLevel, "S_UDT: '%s' -> '%s'\n", data.S_UDT.name, typeName.c_str());
 				}
+				else if (kind == PDB::CodeView::DBI::SymbolRecordKind::S_REGISTER)
+				{
+					const std::string typeName = GetVariableTypeName(typeTable, data.S_REGSYM.typeIndex);
+
+					Printf(blockLevel, "S_REGSYM: '%s' -> '%s' | Register %i\n",
+						data.S_REGSYM.name, typeName.c_str(),
+						data.S_REGSYM.reg);
+				}
+				else if (kind == PDB::CodeView::DBI::SymbolRecordKind::S_BPREL32)
+				{
+					const std::string typeName = GetVariableTypeName(typeTable, data.S_BPRELSYM32.typeIndex);
+
+					Printf(blockLevel, "S_BPRELSYM32: '%s' -> '%s' | BP register Offset 0x%X\n",
+						data.S_BPRELSYM32.name, typeName.c_str(),
+						data.S_BPRELSYM32.offset);
+				}
 				else if (kind == PDB::CodeView::DBI::SymbolRecordKind::S_REGREL32)
 				{
 					const std::string typeName = GetVariableTypeName(typeTable, data.S_REGREL32.typeIndex);
@@ -248,6 +264,16 @@ void ExampleFunctionVariables(const PDB::RawFile& rawPdbFile, const PDB::DBIStre
 						data.S_FRAMEPROC.cbPad, 
 						data.S_FRAMEPROC.offPad, 
 						data.S_FRAMEPROC.cbSaveRegs);
+				}
+				else if (kind == SymbolRecordKind::S_ANNOTATION)
+				{
+					Printf(blockLevel, "S_ANNOTATION: Offset 0x%X | Count %u\n", data.S_ANNOTATIONSYM.offset, data.S_ANNOTATIONSYM.annotationsCount);
+					// print N null-terminated annotation strings, skipping their null-terminators to get to the next string
+					const char* annotation = data.S_ANNOTATIONSYM.annotations;
+					for (int i = 0; i < data.S_ANNOTATIONSYM.annotationsCount; ++i, annotation += strlen(annotation) + 1)
+						Printf(blockLevel + 1, "S_ANNOTATION.%u: %s\n", i, annotation);
+					PDB_ASSERT(annotation <= (const char*)record + record->header.size + sizeof(record->header.size),
+						"Annotation strings end beyond the record size %X; annotaions count: %u", record->header.size, data.S_ANNOTATIONSYM.annotationsCount);
 				}
 				else if (kind == SymbolRecordKind::S_THUNK32)
 				{

--- a/src/Examples/ExampleTypes.cpp
+++ b/src/Examples/ExampleTypes.cpp
@@ -891,6 +891,13 @@ std::string GetTypeName(const TypeTable& typeTable, uint32_t typeIndex)
 
 	if (typeName == nullptr)
 	{
+		if (referencedType == nullptr && (typeIndex & 0x8000'0000) != 0)
+		{
+			// d3d12.pdb\1DEAE23C86E6462A86018FB180EB8E4A1, S_CALLSITE for `dynamic initializer for 'g_Telemetry'': typeIndex == 0x80900001
+			char typeIndexBuf[0x0C];
+			sprintf_s(typeIndexBuf, sizeof(typeIndexBuf), "%08X", typeIndex);
+			return std::string("<BAD_TYPE_INDEX:0x") + typeIndexBuf + ">";
+		}
 		PDB_ASSERT(referencedType != nullptr, "Neither typeName nor referencedType are set.");
 
 		if (referencedType->header.kind == PDB::CodeView::TPI::TypeRecordKind::LF_POINTER)

--- a/src/PDB_DBITypes.h
+++ b/src/PDB_DBITypes.h
@@ -122,11 +122,14 @@ namespace PDB
 				S_END =										0x0006u,		// block, procedure, "with" or thunk end
 				S_SKIP =									0x0007u,        // Reserve symbol space in $$Symbols table
 				S_FRAMEPROC =								0x1012u,		// extra frame and proc information
+				S_ANNOTATION =								0x1019u,		// annotation string literals ("__annotation" intrinsic, e.g. via NT_ASSERT)
 				S_OBJNAME =									0x1101u,		// full path to the original compiled .obj. can point to remote locations and temporary files, not necessarily the file that was linked into the executable
 				S_THUNK32 =									0x1102u,		// thunk start
 				S_BLOCK32 =									0x1103u,		// block start
 				S_LABEL32 =									0x1105u,		// code label
-				S_CONSTANT =        						0x1107u,        // constant symbol
+				S_REGISTER =								0x1106u,		// register variable
+				S_CONSTANT =								0x1107u,		// constant symbol
+				S_BPREL32 =									0x110Bu,		// BP-relative address (almost like S_REGREL32)
 				S_LDATA32 =									0x110Cu,		// (static) local data
 				S_GDATA32 =									0x110Du,		// global data
 				S_PUB32 =									0x110Eu,		// public symbol
@@ -200,6 +203,15 @@ namespace PDB
 			// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvconst.h#L392
 			enum class PDB_NO_DISCARD Register : uint16_t
 			{
+				EAX = 17,
+				ECX = 18,
+				EDX = 19,
+				EBX = 20,
+				ESP = 21,
+				EBP = 22,
+				ESI = 23,
+				EDI = 24,
+
 				RAX = 328,
 				RBX = 329,
 				RCX = 330,
@@ -207,7 +219,18 @@ namespace PDB
 				RSI = 332,
 				RDI = 333,
 				RBP = 334,
-				RSP = 335
+				RSP = 335,
+				R8 = 336,
+				R9 = 337,
+				R10 = 338,
+				R11 = 339,
+				R12 = 340,
+				R13 = 341,
+				R14 = 342,
+				R15 = 343,
+
+				RIP = 33,		// also EIP for x32
+				EFLAGS = 34,	// same for x64 and x32
 			};
 
 
@@ -402,6 +425,14 @@ namespace PDB
 						} flags;
 					} S_FRAMEPROC;
 
+					struct
+					{
+						uint32_t offset;
+						uint16_t section;
+						uint16_t annotationsCount;						// number of zero-terminated annotation strings
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, annotations);	// sequence of zero-terminated annotation strings
+					} S_ANNOTATIONSYM;
+
 					// https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L3696
 					struct
 					{
@@ -501,9 +532,23 @@ namespace PDB
 					{
 						uint32_t offset;
 						uint32_t typeIndex;
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
+					} S_BPRELSYM32;
+
+					struct
+					{
+						uint32_t offset;
+						uint32_t typeIndex;
 						Register reg;
 						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
 					} S_REGREL32, S_REGREL32_ENCTMP;
+
+					struct
+					{
+						uint32_t typeIndex;
+						Register reg;
+						PDB_FLEXIBLE_ARRAY_MEMBER(char, name);
+					} S_REGSYM;
 
 					struct
 					{


### PR DESCRIPTION
Fixed handling of some large private PDB files, including PDBs for x86-32 and ARM64.
Note there's still one assert left in ExampleLines for S_CROSSSCOPEEXPORTS/S_CROSSSCOPEIMPORTS for these PDBs, but at least this one doesn't affect much and is skipped in the release build.

Test PDBs were produced by Microsoft and can be downloaded here: https://pastebin.com/W9MaCmq0 (password: "infected"). Set includes some binaries for easier testing.