### PR TITLE
Fix warning about new error code in examples

### DIFF
--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -39,6 +39,10 @@ namespace
 				printf("Invalid stream index\n");
 				return true;
 
+			case PDB::ErrorCode::InvalidDataSize:
+				printf("Invalid data size\n");
+				return true;
+
 			case PDB::ErrorCode::UnknownVersion:
 				printf("Unknown version\n");
 				return true;


### PR DESCRIPTION
It looks like a new error code was added but not handled in the examples:
```
1>C:\repos\raw_pdb\src\Examples\ExampleMain.cpp(45,3): error C2220: the following warning is treated as an error
1>(compiling source file '/src/Examples/ExampleMain.cpp')
1>C:\repos\raw_pdb\src\Examples\ExampleMain.cpp(45,3): warning C4062: enumerator 'PDB::ErrorCode::InvalidDataSize' in switch of enum 'PDB::ErrorCode' is not handled
```