### PR TITLE
Check TPI stream is valid before creating it

### DIFF
--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -150,13 +150,13 @@ int main(int argc, char** argv)
 		return 5;
 	}
 
-	const PDB::TPIStream tpiStream = PDB::CreateTPIStream(rawPdbFile);
 	if (PDB::HasValidTPIStream(rawPdbFile) != PDB::ErrorCode::Success)
 	{
 		MemoryMappedFile::Close(pdbFile);
 
 		return 5;
 	}
+	const PDB::TPIStream tpiStream = PDB::CreateTPIStream(rawPdbFile);
 
 	// run all examples
 	ExamplePDBSize(rawPdbFile, dbiStream);

--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
 		return 5;
 	}
 
-	if (PDB::HasValidTPIStream(rawPdbFile) != PDB::ErrorCode::Success)
+	if (IsError(PDB::HasValidTPIStream(rawPdbFile)))
 	{
 		MemoryMappedFile::Close(pdbFile);
 


### PR DESCRIPTION
The examples erroneously create a TPI stream before checking that it is valid to do so. This is likely a copy-paste error, as on a first look it seems that we are doing the same for DBI. However, for DBI there are _two_ checks, which has probably created this confusion:

![image](https://github.com/user-attachments/assets/2d7f0de4-e9e5-4f3d-b5c3-21a207c4742e)
