### PR TITLE
Check for IPI Stream

### DIFF
--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -160,6 +160,9 @@ int main(int argc, char** argv)
 	}
 
 	{
+		// It's perfectly possible that an old PDB does not have an IPI stream.
+		// It's not necessarily an error. You can also check the InfoStream for whether
+		// the PDB should have an IPI stream at all.
 		PDB::ErrorCode error = PDB::HasValidIPIStream(rawPdbFile);
 		if (error != PDB::ErrorCode::InvalidStream && IsError(error))
 		{

--- a/src/Examples/ExampleMain.cpp
+++ b/src/Examples/ExampleMain.cpp
@@ -8,6 +8,7 @@
 #include "PDB_InfoStream.h"
 #include "PDB_DBIStream.h"
 #include "PDB_TPIStream.h"
+#include "PDB_IPIStream.h"
 #include "PDB_NamesStream.h"
 
 namespace
@@ -157,6 +158,16 @@ int main(int argc, char** argv)
 
 		return 5;
 	}
+
+	{
+		PDB::ErrorCode error = PDB::HasValidIPIStream(rawPdbFile);
+		if (error != PDB::ErrorCode::InvalidStream && IsError(error))
+		{
+			MemoryMappedFile::Close(pdbFile);
+
+			return 5;
+		}
+	}	
 
 	// run all examples
 	ExamplePDBSize(rawPdbFile, dbiStream);

--- a/src/PDB_IPIStream.cpp
+++ b/src/PDB_IPIStream.cpp
@@ -6,6 +6,7 @@
 #include "PDB_RawFile.h"
 #include "PDB_Util.h"
 #include "PDB_DirectMSFStream.h"
+#include "PDB_InfoStream.h"
 #include "Foundation/PDB_Memory.h"
 
 namespace
@@ -106,6 +107,12 @@ PDB::IPIStream::~IPIStream(void) PDB_NO_EXCEPT
 // ------------------------------------------------------------------------------------------------
 PDB_NO_DISCARD PDB::ErrorCode PDB::HasValidIPIStream(const RawFile& file) PDB_NO_EXCEPT
 {
+	const PDB::InfoStream infoStream(file);
+	if (!infoStream.HasIPIStream())
+	{
+		return ErrorCode::InvalidStream;
+	}
+
 	DirectMSFStream stream = file.CreateMSFStream<DirectMSFStream>(IPIStreamIndex);
 	if (stream.GetSize() < sizeof(IPI::StreamHeader))
 	{

--- a/src/PDB_InfoStream.cpp
+++ b/src/PDB_InfoStream.cpp
@@ -79,9 +79,14 @@ PDB::InfoStream::InfoStream(const RawFile& file) PDB_NO_EXCEPT
 
 	for (size_t i=0u; i < count; ++i)
 	{
-		if (featureCodes[i] == PDB::FeatureCode::MinimalDebugInfo)
+		FeatureCode code = featureCodes[i];
+		if (code == PDB::FeatureCode::MinimalDebugInfo)
 		{
 			m_usesDebugFastlink = true;
+		}
+		else if (code == PDB::FeatureCode::VC110 || code == PDB::FeatureCode::VC140)
+		{
+			m_hasIPIStream = true;
 		}
 	}
 }

--- a/src/PDB_InfoStream.h
+++ b/src/PDB_InfoStream.h
@@ -38,6 +38,11 @@ namespace PDB
 		// Returns whether the module has a names stream.
 		PDB_NO_DISCARD bool HasNamesStream(void) const PDB_NO_EXCEPT;
 
+		PDB_NO_DISCARD inline bool HasIPIStream(void) const PDB_NO_EXCEPT
+		{
+			return m_hasIPIStream;
+		}
+
 		// Create names stream
 		PDB_NO_DISCARD NamesStream CreateNamesStream(const RawFile& file) const PDB_NO_EXCEPT;
 
@@ -46,6 +51,7 @@ namespace PDB
 		const Header* m_header;
 		uint32_t m_namesStreamIndex;
 		bool m_usesDebugFastlink;
+		bool m_hasIPIStream;
 
 		PDB_DISABLE_COPY(InfoStream);
 	};


### PR DESCRIPTION
PDBs created with older toolchains may not have an IPI stream. The stream's presence is advertised in the PDB-stream itself: at the end of the stream, there is a list of "feature codes". If the `VC110` or `VC140` feature code is present, then the PDB has an IPI stream. Otherwise it doesn't.

This PR adds detection for this scenario. I don't have strong feelings for whether the `HasValidIPIStream` should return `ErrorCode::InvalidStream` or something else.